### PR TITLE
feat: purge-aware walk-forward with consistent WF scoring across HPO and final eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,13 +528,19 @@ Commit messages: prefer conventional commits (e.g. `feat: ...`, `fix: ...`, `doc
 - ✅ Config Tooling: `scripts/make_feature_groups.py` converts `features.json` sets into YAML `features.groups`
 - ✅ Unified Export: `scripts/export_from_yaml.py` for YAML-driven production pickles
 
+**Completed in v0.2.0:**
+- ✅ Purge-aware walk-forward backtesting (`EraSplitEvaluator` with `n_purge`, `n_embargo`, `n_splits`)
+- ✅ Consistent HPO scoring: all trials evaluated via 3-fold walk-forward CV (no fixed holdout split)
+- ✅ Full metric parity: walk-forward returns `max_drawdown`, `pct_positive_eras`, `n_valid_eras`
+- ✅ Ensemble diagnostics and submission validation utilities
+- ✅ Per-era feature importance report
+
 **Upcoming:**
-1. **Payout Optimization:** Integrate Numerai payout-style scoring into HPO objective
-2. **Validation:** Better error messages for feature routing mismatches
-5. **Metrics:** Dedicated MMC (Meta-Model Contribution) tests and Numerai benchmark alignment
-6. **CI/CD:** Automated weekly submission pipeline with GitHub Actions
-7. **W&B Integration:** Full experiment tracking and visualization (config exists, needs integration)
-8. **Model Registry:** Versioned model storage with performance tracking
+1. **Validation:** Better error messages for feature routing mismatches
+2. **Metrics:** Dedicated MMC (Meta-Model Contribution) tests and Numerai benchmark alignment
+3. **CI/CD:** Automated weekly submission pipeline with GitHub Actions
+4. **W&B Integration:** Full experiment tracking and visualization (config exists, needs integration)
+5. **Model Registry:** Versioned model storage with performance tracking
 
 -----
 

--- a/scripts/autoresearch.py
+++ b/scripts/autoresearch.py
@@ -3,8 +3,11 @@
 Runs trials within a time/count budget, with a Claude agent deciding what
 to try next (tune hyperparams, add models, change ensemble, etc.).
 
+Each trial is scored via walk-forward backtesting (3 folds) rather than a
+fixed holdout, so the leaderboard reflects temporal out-of-sample performance.
+
 Outputs in --output-dir:
-  best_config.json      Nested pipeline config with the best Sharpe found.
+  best_config.json      Nested pipeline config with the best corr_sharpe found.
   research_state.json   Full trial history + agent reasoning.
   trials_summary.csv    One row per trial with metrics and action taken.
 """
@@ -16,7 +19,7 @@ import tyro
 from loguru import logger
 
 from alphapulse.autoresearch.loop import run_autoresearch
-from alphapulse.experiments.data import load_train_val_frames
+from alphapulse.experiments.data import load_train_only_frame
 
 
 def main(
@@ -52,7 +55,7 @@ def main(
         raise SystemExit(1)
 
     logger.info("Loading data from {} (subsample={:.0%})", data_dir, train_subsample)
-    X_train, y_train, X_val, y_val, era_val, feature_cols = load_train_val_frames(
+    X_train, y_train, feature_cols = load_train_only_frame(
         data_dir,
         train_subsample=train_subsample,
         target_col=target_col,
@@ -60,10 +63,10 @@ def main(
         feature_columns=None,
         need_era=True,
     )
+    era_train = X_train["era"]
     logger.info(
-        "Data loaded: train={}, val={}, features={}",
+        "Data loaded: train={}, features={}",
         X_train.shape,
-        X_val.shape,
         len(feature_cols),
     )
 
@@ -75,9 +78,7 @@ def main(
     state = run_autoresearch(
         X_train,
         y_train,
-        X_val,
-        y_val,
-        era_val,
+        era_train,
         feature_cols,
         max_hours=hours,
         max_trials=trials,

--- a/scripts/export_from_yaml.py
+++ b/scripts/export_from_yaml.py
@@ -22,12 +22,12 @@ from loguru import logger
 from alphapulse.experiments.runner import load_experiment_dict
 from alphapulse.experiments.schema import ExperimentV1
 from alphapulse.experiments.split import internal_val_split
-from alphapulse.hpo.builder import build_pipeline_or_multi
+from alphapulse.hpo.builder import TREE_MODEL_NAMES, build_pipeline_or_multi
 
 
 def _needs_era(exp: ExperimentV1) -> bool:
     for m in exp.models:
-        if m.type == "Packboost":
+        if m.type == "Packboost" or m.type in TREE_MODEL_NAMES:
             return True
         for p in exp.preprocessing + m.preprocessors:
             if p.type == "Packboost":

--- a/scripts/export_numerai_pickle.py
+++ b/scripts/export_numerai_pickle.py
@@ -17,7 +17,7 @@ from loguru import logger
 
 from alphapulse.experiments.data import load_train_only_frame
 from alphapulse.experiments.split import internal_val_split
-from alphapulse.hpo.builder import build_pipeline_or_multi
+from alphapulse.hpo.builder import TREE_MODEL_NAMES, build_pipeline_or_multi
 from alphapulse.hpo.search_space import get_train_kwargs_from_flat, resolve_flat_config
 
 
@@ -26,7 +26,8 @@ def _needs_era_from_flat_config(flat: dict) -> bool:
         return True
     num_models = int(flat.get("num_models", 1))
     for i in range(1, min(num_models, 3) + 1):
-        if flat.get(f"model_{i}_type") == "Packboost":
+        model_type = flat.get(f"model_{i}_type", "")
+        if model_type == "Packboost" or model_type in TREE_MODEL_NAMES:
             return True
     return False
 

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -4,6 +4,10 @@ Supports two modes:
   --local   Random search (no extra dependencies).
   (default) Ray Tune distributed search (requires ``pip install 'alphapulse[hpo]'``).
 
+Each trial is scored via walk-forward backtesting (3 folds, n_purge=4) so
+that the objective reflects temporal out-of-sample performance rather than a
+fixed holdout split. The default objective is corr_sharpe from walk-forward.
+
 Pass --wandb-project <name> to log every trial to Weights & Biases.
 """
 
@@ -16,7 +20,7 @@ from typing import Literal
 import tyro
 from loguru import logger
 
-from alphapulse.experiments.data import load_train_val_frames
+from alphapulse.experiments.data import load_train_only_frame
 from alphapulse.hpo.objective import TrialResult, run_trial
 from alphapulse.hpo.search_space import sample_random_config
 from alphapulse.logging_.leaderboard import (
@@ -24,27 +28,6 @@ from alphapulse.logging_.leaderboard import (
     print_leaderboard,
     save_leaderboard,
 )
-
-
-def _load_meta_model_val(data_dir: Path, val_df_index: object) -> object:
-    """Load meta model predictions aligned to validation index, if available."""
-    import numpy as np
-    import pandas as pd
-
-    meta_path = data_dir / "meta_model.parquet"
-    if not meta_path.exists():
-        return None
-    try:
-        meta_df = pd.read_parquet(meta_path)
-        aligned = meta_df.reindex(val_df_index)  # type: ignore[call-overload]
-        col = (
-            "numerai_meta_model"
-            if "numerai_meta_model" in aligned.columns
-            else aligned.columns[0]
-        )
-        return np.asarray(aligned[col].to_numpy(dtype=np.float64))
-    except Exception:
-        return None
 
 
 def _run_local(
@@ -55,27 +38,24 @@ def _run_local(
     seed: int,
     num_trials: int,
     output_dir: Path,
-    objective: str = "payout_score",
+    objective: str = "corr_sharpe",
     wandb_project: str | None = None,
 ) -> None:
     """Local random-search HPO (no Ray dependency)."""
 
-    need_era = True
-    X_train, y_train, X_val, y_val, era_val, feature_cols = load_train_val_frames(
+    X_train, y_train, feature_cols = load_train_only_frame(
         data_dir,
         train_subsample=train_subsample,
         target_col=target_col,
         seed=seed,
         feature_columns=None,
-        need_era=need_era,
+        need_era=True,
     )
-    meta_model_preds = _load_meta_model_val(data_dir, X_val.index)
+    era_train = X_train["era"]
     logger.info(
-        "Data loaded: train={}, val={}, features={}, meta_model={}",
+        "Data loaded: train={}, features={}",
         X_train.shape,
-        X_val.shape,
         len(feature_cols),
-        "yes" if meta_model_preds is not None else "no",
     )
 
     wandb_group = f"hpo-{uuid.uuid4().hex[:8]}" if wandb_project else None
@@ -96,26 +76,21 @@ def _run_local(
                 flat_config,
                 X_train=X_train,
                 y_train=y_train,
-                X_val=X_val,
-                y_val=y_val,
-                era_val=era_val,
+                era_train=era_train,
                 feature_cols=feature_cols,
                 seed=seed + i,
-                meta_model_preds=meta_model_preds,
             )
             elapsed = time.perf_counter() - t0
-            sharpe = metrics.get("sharpe", float("-inf"))
-            trial_score = float(metrics.get(objective, sharpe))
+            corr_sharpe = metrics.get("corr_sharpe", float("-inf"))
+            trial_score = float(metrics.get(objective, corr_sharpe))
             result = TrialResult(
                 trial_number=i,
-                sharpe=sharpe,
+                sharpe=corr_sharpe,
                 metrics=metrics,
                 model_type=flat_config.get("model_1_type", "XGBoost"),
                 elapsed_seconds=elapsed,
                 params=flat_config,
-                corr_sharpe=metrics.get("corr_sharpe", sharpe),
-                mmc_sharpe=metrics.get("mmc_sharpe"),
-                payout_score=metrics.get("payout_score"),
+                corr_sharpe=corr_sharpe,
             )
         except Exception as e:
             elapsed = time.perf_counter() - t0
@@ -132,17 +107,11 @@ def _run_local(
             )
 
         results.append(result)
-        payout_str = (
-            f" payout={result.payout_score:.4f}"
-            if result.payout_score is not None
-            else ""
-        )
         logger.info(
-            "Trial {}/{}: sharpe={:.4f}{} ({:.1f}s){}",
+            "Trial {}/{}: corr_sharpe={:.4f} ({:.1f}s){}",
             i + 1,
             num_trials,
             result.sharpe,
-            payout_str,
             result.elapsed_seconds,
             f" [ERROR: {result.error}]" if result.error else "",
         )
@@ -171,7 +140,7 @@ def _run_local(
     best_path = output_dir / "best_config.json"
     with open(best_path, "w", encoding="utf-8") as f:
         json.dump(best_config, f, indent=2)
-    logger.info("Best objective score: {:.4f}", best_score)
+    logger.info("Best {} score: {:.4f}", objective, best_score)
     logger.info("Best config saved to: {}", best_path)
 
     all_results_path = output_dir / "all_trials.json"
@@ -211,7 +180,7 @@ def _run_ray(
     seed: int,
     num_trials: int,
     output_dir: Path,
-    objective: str = "payout_score",
+    objective: str = "corr_sharpe",
     wandb_project: str | None = None,
 ) -> None:
     """Ray Tune distributed HPO."""
@@ -229,15 +198,15 @@ def _run_ray(
     from alphapulse.hpo.objective import ray_trainable
     from alphapulse.hpo.search_space import get_full_param_space
 
-    need_era = True
-    X_train, y_train, X_val, y_val, era_val, feature_cols = load_train_val_frames(
+    X_train, y_train, feature_cols = load_train_only_frame(
         data_dir,
         train_subsample=train_subsample,
         target_col=target_col,
         seed=seed,
         feature_columns=None,
-        need_era=need_era,
+        need_era=True,
     )
+    era_train = X_train["era"]
 
     ray.init(ignore_reinit_error=True)
 
@@ -245,16 +214,14 @@ def _run_ray(
         ray_trainable,
         X_train=X_train,
         y_train=y_train,
-        X_val=X_val,
-        y_val=y_val,
-        era_val=era_val,
+        era_train=era_train,
         feature_cols=feature_cols,
     )
 
     param_space = get_full_param_space()
 
     reporter = CLIReporter(
-        metric_columns=["sharpe", "mean_per_era_correlation"],
+        metric_columns=["corr_sharpe", "mean_per_era_correlation"],
         max_report_frequency=30,
     )
 
@@ -316,13 +283,15 @@ def main(
     num_trials: int = 30,
     output_dir: Path = Path("artifacts/hpo"),
     local: bool = False,
-    objective: Literal["sharpe", "corr_sharpe", "payout_score"] = "payout_score",
+    objective: Literal[
+        "corr_sharpe", "mean_per_era_correlation", "max_drawdown"
+    ] = "corr_sharpe",
     wandb_project: str | None = None,
 ) -> None:
     """Run HPO search over preprocessing, models, and ensemble strategies.
 
     Use --local for random search without Ray, or omit for Ray Tune.
-    Use --objective to choose the optimization target (default: payout_score).
+    Use --objective to choose the optimization target (default: corr_sharpe).
     Pass --wandb-project <name> to log every trial to Weights & Biases.
     """
     if local:

--- a/src/alphapulse/autoresearch/loop.py
+++ b/src/alphapulse/autoresearch/loop.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 
-from ..evaluation import Backtester
+from ..evaluation.era_split import EraSplitEvaluator
 from ..hpo.builder import build_pipeline_or_multi
 from ..hpo.search_space import resolve_flat_config, sample_random_config
 from ..logging_.leaderboard import (
@@ -32,15 +32,17 @@ from .mutations import (
 )
 from .state import ResearchState, TrialRecord
 
+_WF_N_SPLITS = 3
+_WF_N_PURGE = 4
+_WF_MIN_TRAIN_ERAS = 20
+
 
 def _run_one_trial(
     config: dict[str, Any],
     *,
     X_train: pd.DataFrame,
     y_train: pd.Series,
-    X_val: pd.DataFrame,
-    y_val: pd.Series,
-    era_val: pd.Series,
+    era_train: pd.Series,
     feature_cols: list[str],
     seed: int,
 ) -> tuple[dict[str, float], float]:
@@ -49,10 +51,18 @@ def _run_one_trial(
     random.seed(seed)
 
     t0 = time.perf_counter()
-    pipeline = build_pipeline_or_multi(config, feature_columns=feature_cols)
-    pipeline.fit(X_train, y_train, X_val=X_val, y_val=y_val)
-    bt = Backtester(pipeline, feature_columns=feature_cols)
-    metrics = bt.evaluate(X_val, y_val, era_val)
+
+    def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:
+        pipeline = build_pipeline_or_multi(config, feature_columns=feature_cols)
+        pipeline.fit(X_tr, y_tr)
+        return pipeline
+
+    metrics = EraSplitEvaluator(
+        feature_columns=feature_cols,
+        n_splits=_WF_N_SPLITS,
+        n_purge=_WF_N_PURGE,
+        min_train_eras=_WF_MIN_TRAIN_ERAS,
+    ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)
     return metrics, time.perf_counter() - t0
 
 
@@ -91,9 +101,7 @@ def _apply_decision(
 def run_autoresearch(
     X_train: pd.DataFrame,
     y_train: pd.Series,
-    X_val: pd.DataFrame,
-    y_val: pd.Series,
-    era_val: pd.Series,
+    era_train: pd.Series,
     feature_cols: list[str],
     *,
     max_hours: float | None = None,
@@ -109,6 +117,10 @@ def run_autoresearch(
 
     Stops when either max_hours wall-clock time or max_trials count is reached,
     whichever comes first. At least one must be provided.
+
+    Each trial scores the pipeline via walk-forward backtesting (n_splits=3)
+    rather than a fixed holdout, so the leaderboard reflects temporal
+    out-of-sample performance.
 
     Args:
         max_hours: Wall-clock budget in hours. None = no limit.
@@ -197,13 +209,11 @@ def run_autoresearch(
                 state.current_config,
                 X_train=X_train,
                 y_train=y_train,
-                X_val=X_val,
-                y_val=y_val,
-                era_val=era_val,
+                era_train=era_train,
                 feature_cols=feature_cols,
                 seed=seed + trial_num,
             )
-            sharpe = metrics.get("sharpe", float("-inf"))
+            sharpe = metrics.get("corr_sharpe", float("-inf"))
             error = None
         except Exception as exc:
             logger.warning("Trial {} failed: {}", trial_num, exc)

--- a/src/alphapulse/autoresearch/loop.py
+++ b/src/alphapulse/autoresearch/loop.py
@@ -12,7 +12,12 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 
-from ..evaluation.era_split import EraSplitEvaluator
+from ..evaluation.era_split import (
+    WF_MIN_TRAIN_ERAS,
+    WF_N_PURGE,
+    WF_N_SPLITS,
+    EraSplitEvaluator,
+)
 from ..hpo.builder import build_pipeline_or_multi
 from ..hpo.search_space import resolve_flat_config, sample_random_config
 from ..logging_.leaderboard import (
@@ -31,10 +36,6 @@ from .mutations import (
     tune_model_params,
 )
 from .state import ResearchState, TrialRecord
-
-_WF_N_SPLITS = 3
-_WF_N_PURGE = 4
-_WF_MIN_TRAIN_ERAS = 20
 
 
 def _run_one_trial(
@@ -59,9 +60,9 @@ def _run_one_trial(
 
     metrics = EraSplitEvaluator(
         feature_columns=feature_cols,
-        n_splits=_WF_N_SPLITS,
-        n_purge=_WF_N_PURGE,
-        min_train_eras=_WF_MIN_TRAIN_ERAS,
+        n_splits=WF_N_SPLITS,
+        n_purge=WF_N_PURGE,
+        min_train_eras=WF_MIN_TRAIN_ERAS,
     ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)
     return metrics, time.perf_counter() - t0
 

--- a/src/alphapulse/evaluation/__init__.py
+++ b/src/alphapulse/evaluation/__init__.py
@@ -1,6 +1,12 @@
 from .backtester import Backtester
 from .ensemble_diagnostics import compute_ensemble_diagnostics
-from .era_split import EraSplitEvaluator, evaluate_holdout_last_n_eras
+from .era_split import (
+    WF_MIN_TRAIN_ERAS,
+    WF_N_PURGE,
+    WF_N_SPLITS,
+    EraSplitEvaluator,
+    evaluate_holdout_last_n_eras,
+)
 from .feature_report import compute_feature_report
 from .metrics import (
     calculate_metrics,
@@ -20,6 +26,9 @@ from .metrics import (
 from .submission import prepare_submission, validate_submission
 
 __all__ = [
+    "WF_MIN_TRAIN_ERAS",
+    "WF_N_PURGE",
+    "WF_N_SPLITS",
     "Backtester",
     "EraSplitEvaluator",
     "compute_ensemble_diagnostics",

--- a/src/alphapulse/evaluation/ensemble_diagnostics.py
+++ b/src/alphapulse/evaluation/ensemble_diagnostics.py
@@ -36,7 +36,6 @@ def correlation_matrix(
     e_arr = np.asarray(eras.to_numpy())
     unique_eras = sorted(pd.unique(e_arr), key=str)
 
-    # For each era, compute rank-normalised predictions, then global correlation
     era_corr_sums = np.zeros((n, n), dtype=np.float64)
     era_count = 0
 
@@ -122,7 +121,6 @@ def compute_ensemble_diagnostics(
 
     eff_count = effective_model_count(w, corr_df)
 
-    # Mean off-diagonal correlation
     mask_off_diag = ~np.eye(n, dtype=bool)
     off_diag_vals = corr_df.to_numpy()[mask_off_diag]
     mean_pairwise = (

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -4,8 +4,20 @@ from typing import Any, Protocol, cast
 import numpy as np
 import pandas as pd
 
+from ..validation.purged_cv import PurgedEraCV
 from .backtester import Backtester
-from .metrics import era_correlation_metrics, per_era_correlation
+from .metrics import calculate_metrics
+
+_NAN_METRICS: dict[str, float] = {
+    "mean_per_era_correlation": float("nan"),
+    "std_per_era_correlation": float("nan"),
+    "corr_sharpe": float("nan"),
+    "sharpe": float("nan"),
+    "correlation": float("nan"),
+    "max_drawdown": float("nan"),
+    "pct_positive_eras": float("nan"),
+    "n_valid_eras": float("nan"),
+}
 
 
 class PredictorProtocol(Protocol):
@@ -37,15 +49,46 @@ def evaluate_holdout_last_n_eras(
 
 
 class EraSplitEvaluator:
-    """Walk-forward: for each test era, fit on prior eras, predict test era."""
+    """Walk-forward backtester with optional purge/embargo gaps.
+
+    Two splitting strategies are available depending on whether *n_splits* is
+    set:
+
+    - **Expanding window** (``n_splits=None``): tests one era at a time.
+      When ``n_purge > 0``, the *n_purge* eras immediately preceding each test
+      era are excluded from training to prevent look-ahead bias (important for
+      Numerai where target windows overlap across adjacent eras).  When
+      ``n_embargo > 0``, consecutive test eras are separated by *n_embargo*
+      skipped eras, so the loop steps by ``n_embargo + 1``.
+
+    - **PurgedEraCV** (``n_splits >= 2``): delegates fold generation to
+      :class:`~alphapulse.validation.purged_cv.PurgedEraCV`, producing
+      *n_splits* folds each containing multiple test eras.  Faster than the
+      expanding window but less granular.
+
+    In both modes the returned metrics dict matches the full output of
+    :func:`~alphapulse.evaluation.metrics.calculate_metrics`.
+    """
 
     def __init__(
         self,
         feature_columns: list[str] | None = None,
         min_train_eras: int = 1,
+        n_purge: int = 4,
+        n_embargo: int = 0,
+        n_splits: int | None = None,
     ) -> None:
+        if n_purge < 0:
+            raise ValueError("n_purge must be >= 0")
+        if n_embargo < 0:
+            raise ValueError("n_embargo must be >= 0")
+        if n_splits is not None and n_splits < 2:
+            raise ValueError("n_splits must be None or >= 2")
         self.feature_columns = feature_columns
         self.min_train_eras = min_train_eras
+        self.n_purge = n_purge
+        self.n_embargo = n_embargo
+        self.n_splits = n_splits
 
     def evaluate_walk_forward(
         self,
@@ -55,67 +98,101 @@ class EraSplitEvaluator:
         train_fn: Callable[[pd.DataFrame, pd.Series], PredictorProtocol],
         eras_order: list[Any] | None = None,
     ) -> dict[str, float]:
-        df = pd.DataFrame({"y": y, "era": era}, index=X.index)
         X_use = X[self.feature_columns] if self.feature_columns is not None else X
-        df = pd.concat([X_use, df], axis=1)
+        df = pd.concat(
+            [X_use, pd.DataFrame({"y": y, "era": era}, index=X.index)], axis=1
+        )
 
         if eras_order is None:
             eras_order = sorted(df["era"].unique(), key=str)
-        if len(eras_order) < self.min_train_eras + 1:
-            return {
-                "mean_per_era_correlation": float("nan"),
-                "std_per_era_correlation": float("nan"),
-                "sharpe": float("nan"),
-                "correlation": float("nan"),
-            }
 
         all_y_true: list[float] = []
         all_y_pred: list[float] = []
         all_era: list[Any] = []
 
-        for i, test_era in enumerate(eras_order):
-            train_eras = eras_order[:i]
+        if self.n_splits is not None:
+            self._collect_purged_cv(
+                df, X_use, train_fn, all_y_true, all_y_pred, all_era
+            )
+        else:
+            self._collect_expanding(
+                df, X_use, eras_order, train_fn, all_y_true, all_y_pred, all_era
+            )
+
+        if not all_y_true:
+            return dict(_NAN_METRICS)
+
+        y_s = pd.Series(all_y_true)
+        era_s = pd.Series(all_era)
+        pred_a = np.asarray(all_y_pred, dtype=np.float64)
+        return calculate_metrics(y_s, pred_a, era_s)
+
+    def _collect_expanding(
+        self,
+        df: pd.DataFrame,
+        X_use: pd.DataFrame,
+        eras_order: list[Any],
+        train_fn: Callable[[pd.DataFrame, pd.Series], PredictorProtocol],
+        all_y_true: list[float],
+        all_y_pred: list[float],
+        all_era: list[Any],
+    ) -> None:
+        step = self.n_embargo + 1
+        first_test = self.min_train_eras + self.n_purge
+        for i in range(first_test, len(eras_order), step):
+            train_end = max(0, i - self.n_purge)
+            train_eras = eras_order[:train_end]
             if len(train_eras) < self.min_train_eras:
                 continue
-            train_mask = df["era"].isin(train_eras)
+            test_era = eras_order[i]
+            train_mask = df["era"].isin(set(train_eras))
             test_mask = df["era"] == test_era
             if not test_mask.any():
                 continue
-
             X_tr = cast(pd.DataFrame, df.loc[train_mask, X_use.columns])
             y_tr = cast(pd.Series, df.loc[train_mask, "y"])
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
             y_te = cast(pd.Series, df.loc[test_mask, "y"])
-
             predictor = train_fn(X_tr, y_tr)
             preds = predictor.predict(X_te)
             all_y_true.extend(y_te.tolist())
             all_y_pred.extend(np.asarray(preds).ravel().tolist())
             all_era.extend([test_era] * len(y_te))
 
-        if not all_y_true:
-            return {
-                "mean_per_era_correlation": float("nan"),
-                "std_per_era_correlation": float("nan"),
-                "sharpe": float("nan"),
-                "correlation": float("nan"),
-            }
+    def _collect_purged_cv(
+        self,
+        df: pd.DataFrame,
+        X_use: pd.DataFrame,
+        train_fn: Callable[[pd.DataFrame, pd.Series], PredictorProtocol],
+        all_y_true: list[float],
+        all_y_pred: list[float],
+        all_era: list[Any],
+    ) -> None:
+        era_series = df["era"]
+        cv = PurgedEraCV(
+            n_splits=self.n_splits,  # type: ignore[arg-type]
+            n_purge=self.n_purge,
+            n_embargo=self.n_embargo,
+            min_train_eras=self.min_train_eras,
+        )
+        for train_eras, test_eras in cv.split_eras(era_series):
+            train_mask = era_series.isin(set(train_eras))
+            test_mask = era_series.isin(set(test_eras))
+            if not test_mask.any():
+                continue
+            X_tr = cast(pd.DataFrame, df.loc[train_mask, X_use.columns])
+            y_tr = cast(pd.Series, df.loc[train_mask, "y"])
+            X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
+            y_te = cast(pd.Series, df.loc[test_mask, "y"])
+            predictor = train_fn(X_tr, y_tr)
+            preds = predictor.predict(X_te)
+            all_y_true.extend(y_te.tolist())
+            all_y_pred.extend(np.asarray(preds).ravel().tolist())
+            all_era.extend(era_series.loc[test_mask].tolist())
 
-        y_s = pd.Series(all_y_true)
-        era_s = pd.Series(all_era)
-        pred_a = np.asarray(all_y_pred, dtype=np.float64)
 
-        per_era = per_era_correlation(y_s, pred_a, era_s)
-        valid = per_era.dropna()
-        scoring = era_correlation_metrics(y_s, pred_a, era_s)
-
-        return {
-            "mean_per_era_correlation": float(valid.mean())
-            if len(valid) > 0
-            else float("nan"),
-            "std_per_era_correlation": float(valid.std())
-            if len(valid) > 1
-            else float("nan"),
-            "sharpe": scoring["corr_sharpe"],
-            "correlation": scoring["mean_era_corr"],
-        }
+__all__ = [
+    "EraSplitEvaluator",
+    "PredictorProtocol",
+    "evaluate_holdout_last_n_eras",
+]

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -153,7 +153,9 @@ class EraSplitEvaluator:
             test_mask = df["era"] == test_era
             if not test_mask.any():
                 continue
-            train_cols = list(X_use.columns) + (["era"] if "era" in df.columns else [])
+            train_cols = list(X_use.columns)
+            if "era" in df.columns and "era" not in X_use.columns:
+                train_cols.append("era")
             X_tr = cast(pd.DataFrame, df.loc[train_mask, train_cols])
             y_tr = cast(pd.Series, df.loc[train_mask, "y"])
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
@@ -185,7 +187,9 @@ class EraSplitEvaluator:
             test_mask = era_series.isin(set(test_eras))
             if not test_mask.any():
                 continue
-            train_cols = list(X_use.columns) + (["era"] if "era" in df.columns else [])
+            train_cols = list(X_use.columns)
+            if "era" in df.columns and "era" not in X_use.columns:
+                train_cols.append("era")
             X_tr = cast(pd.DataFrame, df.loc[train_mask, train_cols])
             y_tr = cast(pd.Series, df.loc[train_mask, "y"])
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -8,6 +8,10 @@ from ..validation.purged_cv import PurgedEraCV
 from .backtester import Backtester
 from .metrics import calculate_metrics
 
+WF_N_SPLITS = 3
+WF_N_PURGE = 4
+WF_MIN_TRAIN_ERAS = 20
+
 _NAN_METRICS: dict[str, float] = {
     "mean_per_era_correlation": float("nan"),
     "std_per_era_correlation": float("nan"),
@@ -149,7 +153,8 @@ class EraSplitEvaluator:
             test_mask = df["era"] == test_era
             if not test_mask.any():
                 continue
-            X_tr = cast(pd.DataFrame, df.loc[train_mask, X_use.columns])
+            train_cols = list(X_use.columns) + (["era"] if "era" in df.columns else [])
+            X_tr = cast(pd.DataFrame, df.loc[train_mask, train_cols])
             y_tr = cast(pd.Series, df.loc[train_mask, "y"])
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
             y_te = cast(pd.Series, df.loc[test_mask, "y"])
@@ -180,7 +185,8 @@ class EraSplitEvaluator:
             test_mask = era_series.isin(set(test_eras))
             if not test_mask.any():
                 continue
-            X_tr = cast(pd.DataFrame, df.loc[train_mask, X_use.columns])
+            train_cols = list(X_use.columns) + (["era"] if "era" in df.columns else [])
+            X_tr = cast(pd.DataFrame, df.loc[train_mask, train_cols])
             y_tr = cast(pd.Series, df.loc[train_mask, "y"])
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
             y_te = cast(pd.Series, df.loc[test_mask, "y"])
@@ -192,6 +198,9 @@ class EraSplitEvaluator:
 
 
 __all__ = [
+    "WF_MIN_TRAIN_ERAS",
+    "WF_N_PURGE",
+    "WF_N_SPLITS",
     "EraSplitEvaluator",
     "PredictorProtocol",
     "evaluate_holdout_last_n_eras",

--- a/src/alphapulse/evaluation/feature_report.py
+++ b/src/alphapulse/evaluation/feature_report.py
@@ -12,6 +12,8 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+_MIN_ERA_SAMPLES = 20
+
 
 def compute_feature_report(
     X: pd.DataFrame,
@@ -69,7 +71,7 @@ def compute_feature_report(
         mask = era_arr == era
         X_era = X[mask]
         y_era = y[mask]
-        if len(X_era) < 20 or float(y_era.std()) == 0.0:
+        if len(X_era) < _MIN_ERA_SAMPLES or float(y_era.std()) == 0.0:
             continue
         model = lgb.LGBMRegressor(
             n_estimators=n_estimators,

--- a/src/alphapulse/evaluation/submission.py
+++ b/src/alphapulse/evaluation/submission.py
@@ -29,19 +29,16 @@ def validate_submission(
     """
     issues: list[str] = []
 
-    # Check prediction column exists
     if pred_col not in predictions_df.columns:
         issues.append(f"Missing required column '{pred_col}'.")
         return issues  # can't check further without predictions
 
     preds = predictions_df[pred_col]
 
-    # Check for NaN predictions
     n_nan = int(preds.isna().sum())
     if n_nan > 0:
         issues.append(f"ERROR: {n_nan} NaN predictions found.")
 
-    # Check predictions are in [0, 1]
     valid_preds = preds.dropna()
     if len(valid_preds) > 0:
         p_min = float(valid_preds.min())
@@ -52,13 +49,11 @@ def validate_submission(
                 f"Got min={p_min:.4f}, max={p_max:.4f}."
             )
 
-    # Check for constant predictions (degenerate)
     if len(valid_preds) > 1 and float(valid_preds.std()) == 0.0:
         issues.append(
             "WARNING: All predictions are identical (constant). This will score 0 CORR."
         )
 
-    # Check for very low variance (near-constant)
     if len(valid_preds) > 10:
         unique_ratio = valid_preds.nunique() / len(valid_preds)
         if unique_ratio < 0.01:
@@ -68,7 +63,6 @@ def validate_submission(
                 "Model may be degenerate."
             )
 
-    # ID alignment check against live data
     if live_df is not None:
         live_ids = set(
             live_df[id_col].tolist()

--- a/src/alphapulse/experiments/runner.py
+++ b/src/alphapulse/experiments/runner.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from ..evaluation import Backtester
 from ..evaluation.era_split import EraSplitEvaluator, evaluate_holdout_last_n_eras
-from ..hpo.builder import build_pipeline_or_multi
+from ..hpo.builder import TREE_MODEL_NAMES, build_pipeline_or_multi
 from ..pipeline.multihead import MultiHeadPipeline
 from ..pipeline.pipeline import Pipeline
 from .data import load_train_frame_with_era, load_train_val_frames
@@ -45,7 +45,7 @@ def load_experiment_dict(path: Path) -> dict[str, Any]:
 
 def _need_era_column(exp: ExperimentV1) -> bool:
     for m in exp.models:
-        if m.type == "Packboost":
+        if m.type == "Packboost" or m.type in TREE_MODEL_NAMES:
             return True
         for p in exp.preprocessing + m.preprocessors:
             if p.type == "Packboost":

--- a/src/alphapulse/experiments/runner.py
+++ b/src/alphapulse/experiments/runner.py
@@ -154,14 +154,14 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
         def train_fn(X_tr: Any, y_tr: Any) -> Pipeline | MultiHeadPipeline:
             p = build_pipeline_or_multi(
                 pipeline_cfg,
-                feature_columns=list(X_tr.columns),
+                feature_columns=feature_cols,
                 feature_groups=exp.features.groups,
             )
             p.fit(X_tr, y_tr, **train_kw)
             return p
 
         wf_metrics = EraSplitEvaluator(
-            feature_columns=list(X_wf.columns),
+            feature_columns=feature_cols,
             min_train_eras=ev.walk_forward_min_train_eras,
             n_purge=ev.walk_forward_n_purge,
             n_embargo=ev.walk_forward_n_embargo,

--- a/src/alphapulse/experiments/runner.py
+++ b/src/alphapulse/experiments/runner.py
@@ -163,6 +163,9 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
         wf_metrics = EraSplitEvaluator(
             feature_columns=list(X_wf.columns),
             min_train_eras=ev.walk_forward_min_train_eras,
+            n_purge=ev.walk_forward_n_purge,
+            n_embargo=ev.walk_forward_n_embargo,
+            n_splits=ev.walk_forward_n_splits,
         ).evaluate_walk_forward(X_wf, y_wf, era_wf, train_fn)
         for k, v in wf_metrics.items():
             metrics[f"walk_forward_{k}"] = v

--- a/src/alphapulse/experiments/schema.py
+++ b/src/alphapulse/experiments/schema.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -99,6 +99,9 @@ class EvaluationConfig(BaseModel):
     era_holdout_last_n: int | None = None
     walk_forward: bool = False
     walk_forward_min_train_eras: int = Field(default=1, ge=1)
+    walk_forward_n_purge: int = Field(default=4, ge=0)
+    walk_forward_n_embargo: int = Field(default=0, ge=0)
+    walk_forward_n_splits: Annotated[int, Field(ge=2)] | None = None
     meta_model_path: str | None = None
     corr_weight: float = Field(default=0.75, ge=0.0)
     mmc_weight: float = Field(default=2.25, ge=0.0)

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -4,9 +4,13 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from ..evaluation import Backtester
+from ..evaluation.era_split import EraSplitEvaluator
 from .builder import build_pipeline_or_multi
 from .search_space import get_train_kwargs_from_flat, resolve_flat_config
+
+_WF_N_SPLITS = 3
+_WF_N_PURGE = 4
+_WF_MIN_TRAIN_ERAS = 20
 
 
 @dataclass(frozen=True)
@@ -32,64 +36,49 @@ def run_trial(
     *,
     X_train: pd.DataFrame,
     y_train: pd.Series,
-    X_val: pd.DataFrame,
-    y_val: pd.Series,
-    era_val: pd.Series,
+    era_train: pd.Series,
     feature_cols: list[str],
     seed: int | None = None,
-    meta_model_preds: np.ndarray | None = None,
-    corr_weight: float = 0.75,
-    mmc_weight: float = 2.25,
 ) -> dict[str, float]:
-    """Train a single HPO trial and return backtest metrics.
+    """Train a single HPO trial and return walk-forward backtest metrics.
+
+    Each trial retrains the model on expanding era windows (n_splits=3) so
+    that the returned metrics reflect out-of-sample temporal performance rather
+    than a fixed holdout split.
 
     Args:
         config: Flat parameter dictionary (as produced by
             ``sample_random_config`` or Ray Tune).
-        X_train: Training feature DataFrame.
+        X_train: Training feature DataFrame (may include an "era" column).
         y_train: Training target Series.
-        X_val: Validation feature DataFrame.
-        y_val: Validation target Series.
-        era_val: Era labels for the validation set.
-        feature_cols: Feature column names.
+        era_train: Era labels aligned to X_train.
+        feature_cols: Feature column names (must not include "era").
         seed: Optional integer seed for reproducibility. Pass a per-trial
             value (e.g. trial number) rather than a fixed constant so that
             parallel Ray workers do not share the same RNG state.
-        meta_model_preds: Optional Numerai meta model predictions for the
-            validation set rows. When provided, ``mmc_sharpe`` and
-            ``payout_score`` are included in the returned metrics.
-        corr_weight: Weight for CORR Sharpe in payout formula. Default 0.75.
-        mmc_weight: Weight for MMC Sharpe in payout formula. Default 2.25.
 
     Returns:
-        Dictionary of backtest metrics (keys include ``sharpe``,
-        ``mean_per_era_correlation``, ``corr_sharpe``, ``max_drawdown``,
-        and optionally ``mmc_sharpe``, ``payout_score``).
+        Dictionary of walk-forward metrics (keys include ``corr_sharpe``,
+        ``mean_per_era_correlation``, ``max_drawdown``, ``pct_positive_eras``,
+        ``n_valid_eras``).
     """
     if seed is not None:
         rng = np.random.default_rng(seed)
         np.random.seed(rng.integers(0, 2**31))
 
     pipeline_cfg = resolve_flat_config(config)
-    pipeline = build_pipeline_or_multi(
-        pipeline_cfg, feature_columns=feature_cols, feature_groups=None
-    )
     train_kwargs = get_train_kwargs_from_flat(config)
 
-    pipeline.fit(
-        X_train,
-        y_train,
-        X_val=X_val,
-        y_val=y_val,
-        **train_kwargs,
-    )
+    def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:
+        pipeline = build_pipeline_or_multi(
+            pipeline_cfg, feature_columns=feature_cols, feature_groups=None
+        )
+        pipeline.fit(X_tr, y_tr, **train_kwargs)
+        return pipeline
 
-    bt = Backtester(pipeline, feature_columns=feature_cols)
-    return bt.evaluate(
-        X_val,
-        y_val,
-        era_val,
-        meta_model_preds=meta_model_preds,
-        corr_weight=corr_weight,
-        mmc_weight=mmc_weight,
-    )
+    return EraSplitEvaluator(
+        feature_columns=feature_cols,
+        n_splits=_WF_N_SPLITS,
+        n_purge=_WF_N_PURGE,
+        min_train_eras=_WF_MIN_TRAIN_ERAS,
+    ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -4,13 +4,14 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from ..evaluation.era_split import EraSplitEvaluator
+from ..evaluation.era_split import (
+    WF_MIN_TRAIN_ERAS,
+    WF_N_PURGE,
+    WF_N_SPLITS,
+    EraSplitEvaluator,
+)
 from .builder import build_pipeline_or_multi
 from .search_space import get_train_kwargs_from_flat, resolve_flat_config
-
-_WF_N_SPLITS = 3
-_WF_N_PURGE = 4
-_WF_MIN_TRAIN_ERAS = 20
 
 
 @dataclass(frozen=True)
@@ -78,7 +79,7 @@ def run_trial(
 
     return EraSplitEvaluator(
         feature_columns=feature_cols,
-        n_splits=_WF_N_SPLITS,
-        n_purge=_WF_N_PURGE,
-        min_train_eras=_WF_MIN_TRAIN_ERAS,
+        n_splits=WF_N_SPLITS,
+        n_purge=WF_N_PURGE,
+        min_train_eras=WF_MIN_TRAIN_ERAS,
     ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)

--- a/tests/test_hpo_pipeline.py
+++ b/tests/test_hpo_pipeline.py
@@ -11,22 +11,20 @@ from alphapulse.hpo import run_trial, sample_random_config
 
 @pytest.fixture
 def toy_data_with_era() -> dict[str, Any]:
-    np.random.seed(42)
-    n = 300
-    X = pd.DataFrame(np.random.randn(n, 4).astype(np.float64), columns=list("ABCD"))
-    X["era"] = np.repeat(["e1", "e2", "e3"], n // 3)
-    y = pd.Series(X["A"] * 0.5 + X["B"] * 0.3 + np.random.randn(n) * 0.2)
-    feature_cols = list("ABCD") + ["era"]
-    era_val = X["era"]
-    X_val = X.iloc[:50]
-    y_val = y.iloc[:50]
-    era_val_small = era_val.iloc[:50]
+    rng = np.random.default_rng(42)
+    n_eras = 40
+    rows_per_era = 8
+    n = n_eras * rows_per_era
+    X = pd.DataFrame(
+        rng.standard_normal((n, 4)).astype(np.float64), columns=list("ABCD")
+    )
+    X["era"] = np.repeat([f"era_{i:04d}" for i in range(n_eras)], rows_per_era)
+    y = pd.Series(X["A"] * 0.5 + X["B"] * 0.3 + rng.standard_normal(n) * 0.2)
+    feature_cols = list("ABCD")
     return {
         "X_train": X,
         "y_train": y,
-        "X_val": X_val,
-        "y_val": y_val,
-        "era_val": era_val_small,
+        "era_train": X["era"],
         "feature_cols": feature_cols,
     }
 
@@ -63,8 +61,8 @@ def test_run_trial_returns_metrics(
     metrics = run_trial(minimal_flat_config, **toy_data_with_era)
     assert isinstance(metrics, dict)
     assert "mean_per_era_correlation" in metrics
-    assert "sharpe" in metrics
-    assert "correlation" in metrics
+    assert "corr_sharpe" in metrics
+    assert "max_drawdown" in metrics
 
 
 def test_sample_random_config_returns_dict() -> None:

--- a/tests/test_new_evaluation.py
+++ b/tests/test_new_evaluation.py
@@ -9,8 +9,6 @@ from alphapulse.evaluation.ensemble_diagnostics import (
 )
 from alphapulse.evaluation.submission import prepare_submission, validate_submission
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
-
 N_ROWS = 120
 N_ERAS = 6
 ERA_SIZE = N_ROWS // N_ERAS
@@ -23,9 +21,6 @@ def _make_eras() -> pd.Series:
 def _make_preds(seed: int) -> np.ndarray:
     rng = np.random.RandomState(seed)
     return rng.randn(N_ROWS)
-
-
-# ── ensemble_diagnostics ──────────────────────────────────────────────────────
 
 
 def test_correlation_matrix_shape() -> None:
@@ -88,9 +83,6 @@ def test_compute_ensemble_diagnostics_with_weights() -> None:
     assert 1.0 <= result["effective_model_count"] <= 2.0 + 1e-6
 
 
-# ── submission ────────────────────────────────────────────────────────────────
-
-
 def test_validate_submission_clean() -> None:
     df = pd.DataFrame({"prediction": np.linspace(0.0, 1.0, 50)})
     issues = validate_submission(df)
@@ -146,9 +138,6 @@ def test_prepare_submission_rank_normalized() -> None:
     df = prepare_submission(preds, ids)
     sorted_preds = df.set_index("id").loc[["b", "c", "a"], "prediction"].values
     assert sorted_preds[0] < sorted_preds[1] < sorted_preds[2]
-
-
-# ── feature_report (integration — requires lightgbm) ─────────────────────────
 
 
 def test_compute_feature_report_basic() -> None:

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -62,9 +62,6 @@ def test_pca_with_era_column() -> None:
     assert list(out.columns) == ["pca_0", "pca_1"]
 
 
-# ── EraStableFeatureSelector ──────────────────────────────────────────────────
-
-
 def test_era_stable_selector_reduces_features() -> None:
     pytest.importorskip("lightgbm")
     from alphapulse.preprocessors.era_stable import EraStableFeatureSelector

--- a/tests/test_review_remediation.py
+++ b/tests/test_review_remediation.py
@@ -47,18 +47,20 @@ def numerai_dataset_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def toy_data_with_era() -> dict[str, Any]:
-    np.random.seed(42)
-    n = 240
-    X = pd.DataFrame(np.random.randn(n, 4).astype(np.float64), columns=list("ABCD"))
-    X["era"] = np.repeat(["e1", "e2", "e3", "e4"], n // 4)
-    y = pd.Series(X["A"] * 0.5 + X["B"] * 0.3 + np.random.randn(n) * 0.2)
-    feature_cols = list("ABCD") + ["era"]
+    rng = np.random.default_rng(42)
+    n_eras = 40
+    rows_per_era = 8
+    n = n_eras * rows_per_era
+    X = pd.DataFrame(
+        rng.standard_normal((n, 4)).astype(np.float64), columns=list("ABCD")
+    )
+    X["era"] = np.repeat([f"era_{i:04d}" for i in range(n_eras)], rows_per_era)
+    y = pd.Series(X["A"] * 0.5 + X["B"] * 0.3 + rng.standard_normal(n) * 0.2)
+    feature_cols = list("ABCD")
     return {
         "X_train": X,
         "y_train": y,
-        "X_val": X.iloc[:60],
-        "y_val": y.iloc[:60],
-        "era_val": X["era"].iloc[:60],
+        "era_train": X["era"],
         "feature_cols": feature_cols,
     }
 
@@ -234,16 +236,14 @@ def test_autoresearch_run_one_trial(toy_data_with_era: dict[str, Any]) -> None:
         seed=0,
         X_train=toy_data_with_era["X_train"],
         y_train=toy_data_with_era["y_train"],
-        X_val=toy_data_with_era["X_val"],
-        y_val=toy_data_with_era["y_val"],
-        era_val=toy_data_with_era["era_val"],
+        era_train=toy_data_with_era["era_train"],
         feature_cols=toy_data_with_era["feature_cols"],
     )
     assert elapsed > 0
-    assert "sharpe" in metrics
+    assert "corr_sharpe" in metrics
 
 
-def test_autoresearch_run_one_trial_accepts_train_kwargs(
+def test_autoresearch_run_one_trial_pipeline_is_fit(
     toy_data_with_era: dict[str, Any],
 ) -> None:
     config = {
@@ -266,12 +266,13 @@ def test_autoresearch_run_one_trial_accepts_train_kwargs(
     }
     with patch("alphapulse.autoresearch.loop.build_pipeline_or_multi") as mock_build:
         mock_pipeline = mock_build.return_value
-        mock_pipeline.fit.return_value = {}
-        with patch("alphapulse.autoresearch.loop.Backtester") as mock_bt:
-            mock_bt.return_value.evaluate.return_value = {"sharpe": 1.0}
-            _run_one_trial(
-                config,
-                seed=0,
-                **toy_data_with_era,
-            )
-            mock_pipeline.fit.assert_called_once()
+        mock_pipeline.predict.side_effect = lambda X: np.zeros(len(X))
+        _run_one_trial(
+            config,
+            seed=0,
+            X_train=toy_data_with_era["X_train"],
+            y_train=toy_data_with_era["y_train"],
+            era_train=toy_data_with_era["era_train"],
+            feature_cols=toy_data_with_era["feature_cols"],
+        )
+        assert mock_pipeline.fit.called

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,198 @@
+"""Tests for purge-aware walk-forward backtesting."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+from sklearn.linear_model import Ridge
+
+from alphapulse.evaluation.era_split import EraSplitEvaluator
+from alphapulse.experiments.schema import EvaluationConfig
+
+
+def _make_data(
+    n_eras: int = 30, rows_per_era: int = 20, n_features: int = 5
+) -> tuple[pd.DataFrame, pd.Series, pd.Series]:
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(
+        rng.standard_normal((n_eras * rows_per_era, n_features)),
+        columns=[f"f{i}" for i in range(n_features)],
+    )
+    y = pd.Series(rng.standard_normal(len(X)), name="target")
+    era = pd.Series(
+        np.repeat([f"era_{i:04d}" for i in range(n_eras)], rows_per_era),
+        name="era",
+    )
+    return X, y, era
+
+
+class _Pred:
+    def __init__(self, model: Ridge) -> None:
+        self._model = model
+
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        return self._model.predict(X)  # type: ignore[no-any-return]
+
+
+def _ridge_train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> _Pred:
+    model = Ridge(alpha=1.0)
+    model.fit(X_tr, y_tr)
+    return _Pred(model)
+
+
+class TestEraSplitEvaluatorDefaults:
+    def test_default_n_purge_is_4(self) -> None:
+        ev = EraSplitEvaluator()
+        assert ev.n_purge == 4
+
+    def test_default_n_embargo_is_0(self) -> None:
+        ev = EraSplitEvaluator()
+        assert ev.n_embargo == 0
+
+    def test_default_n_splits_is_none(self) -> None:
+        ev = EraSplitEvaluator()
+        assert ev.n_splits is None
+
+    def test_invalid_n_purge_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_purge"):
+            EraSplitEvaluator(n_purge=-1)
+
+    def test_invalid_n_embargo_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_embargo"):
+            EraSplitEvaluator(n_embargo=-1)
+
+    def test_invalid_n_splits_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_splits"):
+            EraSplitEvaluator(n_splits=1)
+
+
+class TestPurgeGap:
+    def test_purge_excludes_adjacent_train_eras(self) -> None:
+        """With n_purge=2, eras immediately before each test era are not trained on."""
+        n_purge = 2
+        observed_gaps: list[int] = []
+
+        _, _, era = _make_data(n_eras=20)
+        eras_order = sorted(era.unique(), key=str)
+
+        ev = EraSplitEvaluator(min_train_eras=1, n_purge=n_purge, n_embargo=0)
+
+        step = ev.n_embargo + 1
+        first_test = ev.min_train_eras + ev.n_purge
+
+        for i in range(first_test, len(eras_order), step):
+            train_end = max(0, i - ev.n_purge)
+            train_eras = eras_order[:train_end]
+            if len(train_eras) >= ev.min_train_eras:
+                gap = i - train_end
+                observed_gaps.append(gap)
+
+        assert all(g == n_purge for g in observed_gaps), (
+            f"Expected all gaps == {n_purge}, got {observed_gaps}"
+        )
+
+    def test_no_purge_tests_more_eras(self) -> None:
+        """n_purge=0 should test more eras than n_purge=4 (starts earlier)."""
+        _, _, era = _make_data(n_eras=15)
+
+        eras_order = sorted(era.unique(), key=str)
+
+        counted_with_purge = sum(1 for _ in range(1 + 4, len(eras_order)))
+        counted_no_purge = sum(1 for _ in range(1 + 0, len(eras_order)))
+
+        assert counted_no_purge > counted_with_purge
+
+
+class TestFullMetrics:
+    EXPECTED_KEYS = {
+        "mean_per_era_correlation",
+        "std_per_era_correlation",
+        "corr_sharpe",
+        "sharpe",
+        "correlation",
+        "max_drawdown",
+        "pct_positive_eras",
+        "n_valid_eras",
+    }
+
+    def test_walk_forward_returns_full_metric_set(self) -> None:
+        X, y, era = _make_data(n_eras=20)
+        ev = EraSplitEvaluator(min_train_eras=2, n_purge=2, n_embargo=0)
+        result = ev.evaluate_walk_forward(X, y, era, _ridge_train_fn)
+        assert self.EXPECTED_KEYS.issubset(result.keys()), (
+            f"Missing keys: {self.EXPECTED_KEYS - result.keys()}"
+        )
+
+    def test_walk_forward_values_are_finite(self) -> None:
+        X, y, era = _make_data(n_eras=20)
+        ev = EraSplitEvaluator(min_train_eras=2, n_purge=2, n_embargo=0)
+        result = ev.evaluate_walk_forward(X, y, era, _ridge_train_fn)
+        for key in ("corr_sharpe", "mean_per_era_correlation", "max_drawdown"):
+            assert np.isfinite(result[key]), (
+                f"{key} should be finite, got {result[key]}"
+            )
+
+    def test_nan_metrics_returned_when_no_folds(self) -> None:
+        X, y, era = _make_data(n_eras=5)
+        ev = EraSplitEvaluator(min_train_eras=10, n_purge=0, n_embargo=0)
+        result = ev.evaluate_walk_forward(X, y, era, _ridge_train_fn)
+        assert np.isnan(result["corr_sharpe"])
+        assert np.isnan(result["mean_per_era_correlation"])
+
+
+class TestPurgedCVMode:
+    def test_n_splits_mode_returns_full_metrics(self) -> None:
+        X, y, era = _make_data(n_eras=30)
+        ev = EraSplitEvaluator(min_train_eras=5, n_purge=2, n_embargo=2, n_splits=3)
+        result = ev.evaluate_walk_forward(X, y, era, _ridge_train_fn)
+        expected = {
+            "mean_per_era_correlation",
+            "corr_sharpe",
+            "max_drawdown",
+            "pct_positive_eras",
+            "n_valid_eras",
+        }
+        assert expected.issubset(result.keys())
+
+    def test_n_splits_mode_produces_nonempty_result(self) -> None:
+        X, y, era = _make_data(n_eras=30)
+        ev = EraSplitEvaluator(min_train_eras=5, n_purge=2, n_embargo=2, n_splits=3)
+        result = ev.evaluate_walk_forward(X, y, era, _ridge_train_fn)
+        assert np.isfinite(result["corr_sharpe"])
+
+
+class TestSchemaDefaults:
+    def test_new_fields_exist_with_correct_defaults(self) -> None:
+        cfg = EvaluationConfig()
+        assert cfg.walk_forward_n_purge == 4
+        assert cfg.walk_forward_n_embargo == 0
+        assert cfg.walk_forward_n_splits is None
+
+    def test_n_splits_none_is_valid(self) -> None:
+        cfg = EvaluationConfig(walk_forward_n_splits=None)
+        assert cfg.walk_forward_n_splits is None
+
+    def test_n_splits_ge2_is_valid(self) -> None:
+        cfg = EvaluationConfig(walk_forward_n_splits=5)
+        assert cfg.walk_forward_n_splits == 5
+
+    def test_n_splits_1_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            EvaluationConfig(walk_forward_n_splits=1)
+
+    def test_n_purge_negative_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            EvaluationConfig(walk_forward_n_purge=-1)
+
+    def test_yaml_roundtrip(self) -> None:
+        cfg = EvaluationConfig(
+            walk_forward=True,
+            walk_forward_n_purge=4,
+            walk_forward_n_embargo=2,
+            walk_forward_n_splits=5,
+        )
+        d = cfg.model_dump()
+        cfg2 = EvaluationConfig.model_validate(d)
+        assert cfg2.walk_forward_n_purge == 4
+        assert cfg2.walk_forward_n_embargo == 2
+        assert cfg2.walk_forward_n_splits == 5

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -27,17 +27,19 @@ def _make_data(
 
 
 class _Pred:
-    def __init__(self, model: Ridge) -> None:
+    def __init__(self, model: Ridge, feature_cols: list[str]) -> None:
         self._model = model
+        self._feature_cols = feature_cols
 
     def predict(self, X: pd.DataFrame) -> np.ndarray:
-        return self._model.predict(X)  # type: ignore[no-any-return]
+        return self._model.predict(X[self._feature_cols])  # type: ignore[no-any-return]
 
 
 def _ridge_train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> _Pred:
     model = Ridge(alpha=1.0)
-    model.fit(X_tr, y_tr)
-    return _Pred(model)
+    numeric_cols = [c for c in X_tr.columns if c != "era"]
+    model.fit(X_tr[numeric_cols], y_tr)
+    return _Pred(model, numeric_cols)
 
 
 class TestEraSplitEvaluatorDefaults:


### PR DESCRIPTION
## Summary

- **Walk-forward backtester** (`EraSplitEvaluator`): adds `n_purge`, `n_embargo`, `n_splits` params. Expanding window mode excludes `n_purge` eras before each test era to prevent look-ahead bias. `n_splits` mode delegates to `PurgedEraCV` for fold-based evaluation. Both modes return the full 8-key metric dict (`max_drawdown`, `pct_positive_eras`, `n_valid_eras` included).
- **Schema**: `EvaluationConfig` gains `walk_forward_n_purge` (default 4), `walk_forward_n_embargo` (default 0), `walk_forward_n_splits` (default None) — configurable from YAML.
- **Consistent HPO scoring**: every trial in `run_trial` and `_run_one_trial` now scores via 3-fold WF (`n_splits=3, n_purge=4`) instead of a fixed holdout. Leaderboard metric is `corr_sharpe` from WF, matching the final evaluation. HPO default objective changed from `payout_score` → `corr_sharpe`.
- **Data loading**: autoresearch and HPO scripts switch to `load_train_only_frame` (no separate val split needed for scoring).