### PR TITLE
docs: update roadmap with pre-training critical path from architecture audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,12 +535,31 @@ Commit messages: prefer conventional commits (e.g. `feat: ...`, `fix: ...`, `doc
 - ✅ Ensemble diagnostics and submission validation utilities
 - ✅ Per-era feature importance report
 
-**Upcoming:**
-1. **Validation:** Better error messages for feature routing mismatches
-2. **Metrics:** Dedicated MMC (Meta-Model Contribution) tests and Numerai benchmark alignment
-3. **CI/CD:** Automated weekly submission pipeline with GitHub Actions
-4. **W&B Integration:** Full experiment tracking and visualization (config exists, needs integration)
-5. **Model Registry:** Versioned model storage with performance tracking
+**Completed in v0.3.0:**
+- ✅ Validation: clear error messages for feature routing mismatches (`input_group` validated at YAML parse time; `HeadSpec` distinguishes undefined group vs missing columns)
+- ✅ MMC metric tests: full test coverage for `mmc_score`, `per_era_mmc`, `era_sharpe_of_mmc`, and `payout_score`
+
+**Upcoming — v0.4.0 (Pre-Training Critical Path):**
+
+*Must be resolved before the first serious full-dataset training run.*
+
+1. **Global seed threading:** Centralized `set_global_seed()` utility invoked at script genesis — locks Python `random`, `numpy`, `torch`, and cross-validation subsampling to guarantee identical walk-forward splits across independent executions.
+2. **Nested early stopping:** Decouple early-stopping validation from the outer holdout fold. Each walk-forward training fold must carve an inner temporal validation set (respecting purge/embargo) exclusively for loss monitoring; the outer fold remains untouched for metric reporting.
+3. **Per-era rank normalization before metrics:** Enforce `rank_normalize()` strictly per era (not globally) before any correlation or Sharpe computation, matching Numerai's exact scoring pipeline.
+4. **Feature schema contract:** Serialise the exact ordered feature list into every artifact; validate incoming data against it at load time — fail fast on missing columns, silently drop unexpected ones.
+5. **OOM protection / lazy data loading:** Transition from full in-memory loading to memory-mapped or streaming access for the full dataset; use native `DMatrix`/`Dataset` formats for tree models to avoid 3× memory spikes during histogram construction.
+6. **Export artifact smoke test:** After serialising `predict.pkl`, spawn a clean subprocess that loads it and runs a forward pass on a synthetic frame with edge-case columns — only mark the artifact as deployment-ready on success.
+7. **Column taxonomy:** Tag every dataset column as `feature | target | auxiliary_target | metadata | benchmark` in config; guarantee benchmark columns (e.g. `v2_equivalent_return`) bypass model training but reach the evaluation module intact.
+
+**Upcoming — v0.5.0 (Production Hardening):**
+
+8. **HPO fault tolerance:** Back the optimization sweep with a persistent trial database; isolate each trial in a subprocess so a crash marks that trial failed and the sweep continues; checkpoint deep-learning weights per epoch.
+9. **Provenance artifact:** On every successful trial, save a hermetically sealed bundle: resolved config, `uv export` dependency snapshot, and the git commit hash — verify the environment on resume/deploy.
+10. **Canonical artifact naming:** Enforce `<TIMESTAMP>_<ARCH>_<TARGET>_<CONFIG_HASH>.pkl` for all exported models to prevent overwrite collisions and enable automated deployment selection.
+11. **Masked loss for auxiliary targets:** Implement per-column boolean masking in multi-task neural losses so `NaN`-sparse auxiliary targets contribute valid gradients without crashing backpropagation.
+12. **Feature neutralization in eval loop:** Project predictions orthogonally to the Numerai Neutralizers Matrix before computing selection metrics, rewarding genuinely novel alpha over crowded factor exposure.
+13. **W&B Integration:** Full experiment tracking — co-locate configs, per-era metrics, and artifacts in a searchable run database (config scaffolding already exists).
+14. **CI/CD:** Automated weekly submission pipeline with GitHub Actions (download → infer → submit).
 
 -----
 


### PR DESCRIPTION
## Summary

Updates the roadmap based on a deep architectural audit identifying gaps that must be resolved before the first serious full-dataset training run.

- Marks v0.3.0 items as completed (feature routing validation, MMC tests)
- Adds **v0.4.0 Pre-Training Critical Path** (7 items): global seed threading, nested early stopping, per-era rank normalization, feature schema contract, OOM protection, export smoke test, column taxonomy
- Adds **v0.5.0 Production Hardening** (7 items): HPO fault tolerance, provenance artifacts, canonical naming, masked auxiliary loss, feature neutralization in eval, W&B integration, CI/CD