### PR TITLE
feat: v0.4.0 pre-training critical path (7 architectural fixes)

### DIFF
--- a/scripts/autoresearch.py
+++ b/scripts/autoresearch.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 from alphapulse.autoresearch.loop import run_autoresearch
 from alphapulse.experiments.data import load_train_only_frame
+from alphapulse.utils import set_global_seed
 
 
 def main(
@@ -50,6 +51,7 @@ def main(
         resume: Resume from existing research_state.json in output_dir.
         wandb_project: WandB project name. When set, logs all trials to W&B.
     """
+    set_global_seed(seed)
     if hours is None and trials is None:
         logger.error("Provide at least one of --hours or --trials.")
         raise SystemExit(1)

--- a/scripts/export_from_yaml.py
+++ b/scripts/export_from_yaml.py
@@ -19,6 +19,7 @@ import cloudpickle
 import tyro
 from loguru import logger
 
+from alphapulse.evaluation.export_validation import smoke_test_predict_fn
 from alphapulse.experiments.runner import load_experiment_dict
 from alphapulse.experiments.schema import ExperimentV1
 from alphapulse.experiments.split import internal_val_split
@@ -121,12 +122,16 @@ def main(
     )
 
     predict_fn = pipeline.to_numerai_predict(benchmark_col)
-    with open(output_dir / "predict.pkl", "wb") as f:
+    pkl_path = output_dir / "predict.pkl"
+    with open(pkl_path, "wb") as f:
         cloudpickle.dump(predict_fn, f)
+
+    smoke_test_predict_fn(pkl_path, feature_cols)
+    logger.info("Smoke test passed for {}", pkl_path)
 
     pipeline.save_pipeline(output_dir / "pipeline.pkl")
 
-    logger.info("Exported Numerai predict to: {}", output_dir / "predict.pkl")
+    logger.info("Exported Numerai predict to: {}", pkl_path)
     logger.info("Saved trained pipeline to:   {}", output_dir / "pipeline.pkl")
 
 

--- a/scripts/export_numerai_pickle.py
+++ b/scripts/export_numerai_pickle.py
@@ -15,10 +15,12 @@ import cloudpickle
 import tyro
 from loguru import logger
 
+from alphapulse.evaluation.export_validation import smoke_test_predict_fn
 from alphapulse.experiments.data import load_train_only_frame
 from alphapulse.experiments.split import internal_val_split
 from alphapulse.hpo.builder import TREE_MODEL_NAMES, build_pipeline_or_multi
 from alphapulse.hpo.search_space import get_train_kwargs_from_flat, resolve_flat_config
+from alphapulse.utils import set_global_seed
 
 
 def _needs_era_from_flat_config(flat: dict) -> bool:
@@ -42,6 +44,7 @@ def main(
     output_dir: Path = Path("artifacts/competition_pickle_x8"),
 ) -> None:
     """Train best HPO config on subsampled data and export `predict.pkl`."""
+    set_global_seed(seed)
 
     if not best_config_path.exists():
         raise FileNotFoundError(f"best_config_path not found: {best_config_path}")
@@ -112,12 +115,16 @@ def main(
     )
 
     predict_fn = pipeline.to_numerai_predict()
-    with open(output_dir / "predict.pkl", "wb") as f:
+    pkl_path = output_dir / "predict.pkl"
+    with open(pkl_path, "wb") as f:
         cloudpickle.dump(predict_fn, f)
+
+    smoke_test_predict_fn(pkl_path, feature_cols)
+    logger.info("Smoke test passed for {}", pkl_path)
 
     pipeline.save_pipeline(output_dir / "pipeline.pkl")
 
-    logger.info("Exported Numerai predict to: {}", output_dir / "predict.pkl")
+    logger.info("Exported Numerai predict to: {}", pkl_path)
     logger.info("Saved trained pipeline to:   {}", output_dir / "pipeline.pkl")
 
 

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -28,6 +28,7 @@ from alphapulse.logging_.leaderboard import (
     print_leaderboard,
     save_leaderboard,
 )
+from alphapulse.utils import set_global_seed
 
 
 def _run_local(
@@ -294,6 +295,7 @@ def main(
     Use --objective to choose the optimization target (default: corr_sharpe).
     Pass --wandb-project <name> to log every trial to Weights & Biases.
     """
+    set_global_seed(seed)
     if local:
         _run_local(
             data_dir=data_dir,

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -6,12 +6,16 @@ from typing import Any
 
 import tyro
 
+from alphapulse.utils import set_global_seed
+
 
 def main(
     config: Path = Path("experiments/example_v1.yaml"),
     artifact_dir: Path | None = Path("artifacts/experiments"),
+    seed: int = 42,
 ) -> None:
     """Load experiment file, train, evaluate; print metrics and config hash."""
+    set_global_seed(seed)
     from alphapulse.experiments import run_experiment_from_path
 
     result = run_experiment_from_path(config, artifact_dir=artifact_dir)

--- a/scripts/run_test_pipeline.py
+++ b/scripts/run_test_pipeline.py
@@ -11,17 +11,20 @@ from alphapulse.logging_ import init_wandb, log_backtest_results, log_metrics
 from alphapulse.models.xgboost_model import XGBoostModel
 from alphapulse.pipeline import Pipeline
 from alphapulse.preprocessors.scaling import StandardScalerPreprocessor
+from alphapulse.utils import set_global_seed
 
 
 def main(
     data_dir: Path = Path("data/v5.2"),
     train_subsample: float = 0.05,
     target_col: str = "target",
+    seed: int = 42,
     output_dir: Path = Path("artifacts"),
     wandb_project: str = "alphapulse-test",
     wandb_run_name: str | None = None,
 ) -> None:
     """Run test pipeline: load data, train, backtest, log to wandb, save pickle."""
+    set_global_seed(seed)
     train_path = data_dir / "train.parquet"
     val_path = data_dir / "validation.parquet"
     if not train_path.exists() or not val_path.exists():

--- a/src/alphapulse/evaluation/__init__.py
+++ b/src/alphapulse/evaluation/__init__.py
@@ -7,6 +7,7 @@ from .era_split import (
     EraSplitEvaluator,
     evaluate_holdout_last_n_eras,
 )
+from .export_validation import smoke_test_predict_fn
 from .feature_report import compute_feature_report
 from .metrics import (
     calculate_metrics,
@@ -22,6 +23,7 @@ from .metrics import (
     per_era_mmc,
     per_era_spearman,
     rank_normalize,
+    rank_normalize_per_era,
 )
 from .submission import prepare_submission, validate_submission
 
@@ -49,4 +51,6 @@ __all__ = [
     "per_era_spearman",
     "payout_score",
     "rank_normalize",
+    "rank_normalize_per_era",
+    "smoke_test_predict_fn",
 ]

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from ..validation.purged_cv import PurgedEraCV
 from .backtester import Backtester
-from .metrics import calculate_metrics
+from .metrics import calculate_metrics, rank_normalize_per_era
 
 WF_N_SPLITS = 3
 WF_N_PURGE = 4
@@ -128,7 +128,7 @@ class EraSplitEvaluator:
 
         y_s = pd.Series(all_y_true)
         era_s = pd.Series(all_era)
-        pred_a = np.asarray(all_y_pred, dtype=np.float64)
+        pred_a = rank_normalize_per_era(np.asarray(all_y_pred, dtype=np.float64), era_s)
         return calculate_metrics(y_s, pred_a, era_s)
 
     def _collect_expanding(

--- a/src/alphapulse/evaluation/export_validation.py
+++ b/src/alphapulse/evaluation/export_validation.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def smoke_test_predict_fn(
+    pkl_path: Path,
+    feature_columns: list[str],
+    n_rows: int = 10,
+) -> None:
+    """Validate that a serialized predict.pkl works end-to-end.
+
+    Loads the pickle, constructs synthetic input DataFrames (with correct
+    features plus unexpected extra columns), calls the function, and asserts
+    the output has the correct shape and values in [0, 1].
+
+    Args:
+        pkl_path: Path to the cloudpickle-serialized predict function.
+        feature_columns: Expected feature column names used during training.
+        n_rows: Number of synthetic rows to test with.
+
+    Raises:
+        RuntimeError: If the predict function cannot be loaded or produces
+            invalid output (wrong type, missing column, wrong length, or
+            out-of-range values).
+    """
+    import cloudpickle
+
+    try:
+        with open(pkl_path, "rb") as f:
+            predict_fn = cloudpickle.load(f)
+    except Exception as exc:
+        raise RuntimeError(f"smoke_test: failed to load {pkl_path}: {exc}") from exc
+
+    extra_cols = ["__smoke_extra_1__", "__smoke_extra_2__"]
+    all_cols = list(feature_columns) + extra_cols
+    rng = np.random.default_rng(0)
+    live_features = pd.DataFrame(rng.random((n_rows, len(all_cols))), columns=all_cols)
+    live_benchmark_models = pd.DataFrame(
+        {"v2_equivalent_return": rng.random(n_rows)},
+    )
+
+    try:
+        result = predict_fn(live_features, live_benchmark_models)
+    except Exception as exc:
+        raise RuntimeError(
+            f"smoke_test: predict_fn raised on synthetic input: {exc}"
+        ) from exc
+
+    if not isinstance(result, pd.DataFrame):
+        raise RuntimeError(
+            f"smoke_test: expected DataFrame output, got {type(result).__name__}"
+        )
+    if "prediction" not in result.columns:
+        raise RuntimeError(
+            "smoke_test: output missing 'prediction' column. "
+            f"Got: {list(result.columns)}"
+        )
+    if len(result) != n_rows:
+        raise RuntimeError(f"smoke_test: expected {n_rows} rows, got {len(result)}")
+    preds = result["prediction"].to_numpy(dtype=np.float64)
+    finite = np.isfinite(preds)
+    if not finite.all():
+        raise RuntimeError(
+            f"smoke_test: {(~finite).sum()} non-finite prediction value(s)"
+        )
+    if (preds < 0.0).any() or (preds > 1.0).any():
+        raise RuntimeError(
+            "smoke_test: predictions out of [0, 1]: "
+            f"min={preds.min():.4f}, max={preds.max():.4f}"
+        )

--- a/src/alphapulse/evaluation/metrics.py
+++ b/src/alphapulse/evaluation/metrics.py
@@ -26,6 +26,34 @@ def rank_normalize(predictions: np.ndarray) -> np.ndarray:
     return out
 
 
+def rank_normalize_per_era(
+    predictions: np.ndarray,
+    eras: pd.Series,
+) -> np.ndarray:
+    """Rank-normalize predictions independently within each era.
+
+    Applies ``rank_normalize`` per era so that the output matches the
+    cross-sectional [0, 1] uniform distribution Numerai uses before scoring.
+    Rows whose era produces fewer than 2 finite predictions are left as NaN.
+
+    Args:
+        predictions: Raw model predictions aligned with *eras*.
+        eras: Era labels with the same length as *predictions*.
+
+    Returns:
+        Array of rank-normalized predictions, same shape as *predictions*.
+    """
+    p = np.asarray(predictions, dtype=np.float64)
+    e = np.asarray(eras.to_numpy())
+    if len(p) != len(e):
+        raise ValueError("predictions and eras must have the same length.")
+    out = np.full_like(p, fill_value=np.nan)
+    for era in pd.unique(e):
+        mask = e == era
+        out[mask] = rank_normalize(p[mask])
+    return out
+
+
 def _corr_pearson(x: np.ndarray, y: np.ndarray) -> float:
     if x.size < 2:
         return float("nan")

--- a/src/alphapulse/experiments/data.py
+++ b/src/alphapulse/experiments/data.py
@@ -51,13 +51,15 @@ def resolve_feature_columns(
     train_df: pd.DataFrame,
     data_dir: Path,
     explicit: list[str] | None,
+    benchmark_columns: list[str] | None = None,
 ) -> list[str]:
+    excluded = set(benchmark_columns or [])
     if explicit:
-        return [c for c in explicit if c in train_df.columns]
+        return [c for c in explicit if c in train_df.columns and c not in excluded]
     feature_names = load_feature_names(data_dir)
     if feature_names:
-        return [c for c in feature_names if c in train_df.columns]
-    meta = {"id", "era", "target"}
+        return [c for c in feature_names if c in train_df.columns and c not in excluded]
+    meta = {"id", "era", "target"} | excluded
     meta.update(c for c in train_df.columns if c.startswith("target_"))
     return [
         c
@@ -73,6 +75,7 @@ def load_train_val_frames(
     seed: int,
     feature_columns: list[str] | None,
     need_era: bool,
+    benchmark_columns: list[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series, pd.Series, list[str]]:
     if train_subsample <= 0.0:
         raise ValueError(f"train_subsample must be > 0, got {train_subsample}")
@@ -85,17 +88,20 @@ def load_train_val_frames(
             "Run scripts/download_dataset.py first."
         )
 
+    excluded = set(benchmark_columns or [])
     feature_names = feature_columns or load_feature_names(data_dir)
     extra_cols = [target_col] + (["era"] if need_era else [])
     if feature_names:
         read_cols = list(dict.fromkeys(feature_names + extra_cols + ["era"]))
         train_df = pd.read_parquet(train_path, columns=read_cols)
         val_df = pd.read_parquet(val_path, columns=read_cols)
-        cols = [c for c in feature_names if c in train_df.columns]
+        cols = [c for c in feature_names if c in train_df.columns and c not in excluded]
     else:
         train_df = pd.read_parquet(train_path)
         val_df = pd.read_parquet(val_path)
-        cols = resolve_feature_columns(train_df, data_dir, feature_columns)
+        cols = resolve_feature_columns(
+            train_df, data_dir, feature_columns, benchmark_columns
+        )
 
     if not cols:
         raise ValueError("No feature columns resolved.")
@@ -122,12 +128,14 @@ def load_train_only_frame(
     feature_columns: list[str] | None,
     need_era: bool,
     feature_set: str | None = None,
+    benchmark_columns: list[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, list[str]]:
     """Load only train.parquet (no validation) with column pruning to reduce RAM."""
     train_path = data_dir / "train.parquet"
     if not train_path.exists():
         raise FileNotFoundError(f"Expected {train_path}")
 
+    excluded = set(benchmark_columns or [])
     feature_names = feature_columns or load_feature_names(
         data_dir, feature_set=feature_set
     )
@@ -136,10 +144,12 @@ def load_train_only_frame(
             dict.fromkeys(feature_names + [target_col] + (["era"] if need_era else []))
         )
         train_df = pd.read_parquet(train_path, columns=read_cols)
-        cols = [c for c in feature_names if c in train_df.columns]
+        cols = [c for c in feature_names if c in train_df.columns and c not in excluded]
     else:
         train_df = pd.read_parquet(train_path)
-        cols = resolve_feature_columns(train_df, data_dir, feature_columns)
+        cols = resolve_feature_columns(
+            train_df, data_dir, feature_columns, benchmark_columns
+        )
 
     if not cols:
         raise ValueError("No feature columns resolved.")
@@ -159,17 +169,29 @@ def load_train_frame_with_era(
     seed: int,
     feature_columns: list[str] | None,
     need_era: bool,
+    benchmark_columns: list[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.Series, list[str]]:
     train_path = data_dir / "train.parquet"
     if not train_path.exists():
         raise FileNotFoundError(f"Expected {train_path}")
-    train_df = pd.read_parquet(train_path)
-    cols = resolve_feature_columns(train_df, data_dir, feature_columns)
+
+    excluded = set(benchmark_columns or [])
+    feature_names = feature_columns or load_feature_names(data_dir)
+    if feature_names:
+        read_cols = list(dict.fromkeys(feature_names + [target_col, "era"]))
+        train_df = pd.read_parquet(train_path, columns=read_cols)
+        cols = [c for c in feature_names if c in train_df.columns and c not in excluded]
+    else:
+        train_df = pd.read_parquet(train_path)
+        cols = resolve_feature_columns(
+            train_df, data_dir, feature_columns, benchmark_columns
+        )
+
     if not cols:
         raise ValueError("No feature columns resolved.")
     cols = [c for c in cols if c not in {"era", "id"}]
     if not cols:
         raise ValueError("No feature columns resolved after excluding metadata.")
-    read_cols = cols + (["era"] if need_era else [])
+    x_cols = cols + (["era"] if need_era else [])
     train_df = train_df.sample(frac=train_subsample, random_state=seed)
-    return train_df[read_cols], train_df[target_col], train_df["era"], cols
+    return train_df[x_cols], train_df[target_col], train_df["era"], cols

--- a/src/alphapulse/experiments/runner.py
+++ b/src/alphapulse/experiments/runner.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import time
 from dataclasses import dataclass, field
@@ -87,6 +88,7 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
             seed=exp.data.seed,
             feature_columns=exp.features.columns,
             need_era=need_era,
+            benchmark_columns=exp.data.benchmark_columns or None,
         )
     except Exception as e:
         logger.exception("Experiment data load failed")
@@ -130,6 +132,7 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
             pipeline_config=pipeline_cfg,
         )
 
+    gc.collect()
     backtester = Backtester(pipeline, feature_columns=feature_cols)
     metrics = backtester.evaluate(X_val, y_val, era_val)
 
@@ -149,6 +152,7 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
             seed=exp.data.seed,
             feature_columns=exp.features.columns,
             need_era=need_era,
+            benchmark_columns=exp.data.benchmark_columns or None,
         )
 
         def train_fn(X_tr: Any, y_tr: Any) -> Pipeline | MultiHeadPipeline:
@@ -157,7 +161,11 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
                 feature_columns=feature_cols,
                 feature_groups=exp.features.groups,
             )
-            p.fit(X_tr, y_tr, **train_kw)
+            era_col = X_tr["era"] if "era" in X_tr.columns else None
+            X_fit, y_fit, X_val_inner, y_val_inner = internal_val_split(
+                X_tr, y_tr, era_train=era_col
+            )
+            p.fit(X_fit, y_fit, X_val=X_val_inner, y_val=y_val_inner, **train_kw)
             return p
 
         wf_metrics = EraSplitEvaluator(

--- a/src/alphapulse/experiments/schema.py
+++ b/src/alphapulse/experiments/schema.py
@@ -42,6 +42,7 @@ class DataConfig(BaseModel):
     target_col: str = "target"
     seed: int = 42
     auxiliary_targets: list[str] | None = None
+    benchmark_columns: list[str] = Field(default_factory=list)
 
 
 class FeatureConfig(BaseModel):

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -10,6 +10,7 @@ from ..evaluation.era_split import (
     WF_N_SPLITS,
     EraSplitEvaluator,
 )
+from ..experiments.split import internal_val_split
 from .builder import build_pipeline_or_multi
 from .search_space import get_train_kwargs_from_flat, resolve_flat_config
 
@@ -74,7 +75,11 @@ def run_trial(
         pipeline = build_pipeline_or_multi(
             pipeline_cfg, feature_columns=feature_cols, feature_groups=None
         )
-        pipeline.fit(X_tr, y_tr, **train_kwargs)
+        era_col = X_tr["era"] if "era" in X_tr.columns else None
+        X_fit, y_fit, X_val_inner, y_val_inner = internal_val_split(
+            X_tr, y_tr, era_train=era_col
+        )
+        pipeline.fit(X_fit, y_fit, X_val=X_val_inner, y_val=y_val_inner, **train_kwargs)
         return pipeline
 
     return EraSplitEvaluator(

--- a/src/alphapulse/pipeline/multihead.py
+++ b/src/alphapulse/pipeline/multihead.py
@@ -269,7 +269,7 @@ class MultiHeadPipeline:
             live_features: pd.DataFrame,
             live_benchmark_models: pd.DataFrame,
         ) -> pd.DataFrame:
-            X = live_features[feature_columns]
+            X = live_features.reindex(columns=feature_columns, fill_value=0.0)
             raw_preds = pipeline.predict(X)
             ranked = rank_normalize(raw_preds)
 

--- a/src/alphapulse/pipeline/pipeline.py
+++ b/src/alphapulse/pipeline/pipeline.py
@@ -264,6 +264,25 @@ class Pipeline:
         )
         return rank_normalize(neutralized)
 
+    def validate_feature_schema(self, X: pd.DataFrame) -> None:
+        """Warn about columns present in training but missing from *X*.
+
+        Args:
+            X: DataFrame to validate against the training feature schema.
+        """
+        import warnings
+
+        if not self.feature_columns:
+            return
+        missing = [c for c in self.feature_columns if c not in X.columns]
+        if missing:
+            warnings.warn(
+                f"Feature schema mismatch: {len(missing)} training column(s) absent "
+                f"from input (will be zero-filled): {missing[:10]}"
+                + (" …" if len(missing) > 10 else ""),
+                stacklevel=2,
+            )
+
     def to_numerai_predict(
         self,
         benchmark_col: str | None = None,
@@ -291,7 +310,7 @@ class Pipeline:
             live_features: pd.DataFrame,
             live_benchmark_models: pd.DataFrame,
         ) -> pd.DataFrame:
-            X = live_features[feature_columns]
+            X = live_features.reindex(columns=feature_columns, fill_value=0.0)
             eras = (
                 live_features["era"]
                 if use_neutralization and "era" in live_features.columns

--- a/src/alphapulse/utils/__init__.py
+++ b/src/alphapulse/utils/__init__.py
@@ -1,0 +1,3 @@
+from .seed import set_global_seed
+
+__all__ = ["set_global_seed"]

--- a/src/alphapulse/utils/seed.py
+++ b/src/alphapulse/utils/seed.py
@@ -1,0 +1,33 @@
+import os
+import random
+
+import numpy as np
+
+
+def set_global_seed(seed: int) -> None:
+    """Lock all RNG sources to a single seed for reproducibility.
+
+    Sets Python ``random``, NumPy, and PyTorch (if available).
+    Also fixes ``PYTHONHASHSEED`` so dictionary ordering is deterministic
+    within the current process.
+
+    Args:
+        seed: Integer seed value. Must be non-negative.
+    """
+    if seed < 0:
+        raise ValueError(f"seed must be non-negative, got {seed}")
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+
+    try:
+        import torch
+
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+    except ImportError:
+        pass

--- a/src/alphapulse/utils/seed.py
+++ b/src/alphapulse/utils/seed.py
@@ -8,8 +8,9 @@ def set_global_seed(seed: int) -> None:
     """Lock all RNG sources to a single seed for reproducibility.
 
     Sets Python ``random``, NumPy, and PyTorch (if available).
-    Also fixes ``PYTHONHASHSEED`` so dictionary ordering is deterministic
-    within the current process.
+    Also sets ``PYTHONHASHSEED`` in the environment so that any child
+    processes (e.g. Ray workers) inherit a fixed hash seed.  Note: this has
+    no effect on the current interpreter, which reads the variable at startup.
 
     Args:
         seed: Integer seed value. Must be non-negative.

--- a/tests/test_v040_features.py
+++ b/tests/test_v040_features.py
@@ -1,0 +1,282 @@
+"""Tests for v0.4.0 pre-training critical path features."""
+
+import random
+import tempfile
+import warnings
+from pathlib import Path
+
+import cloudpickle
+import numpy as np
+import pandas as pd
+import pytest
+
+from alphapulse.evaluation.export_validation import smoke_test_predict_fn
+from alphapulse.evaluation.metrics import rank_normalize, rank_normalize_per_era
+from alphapulse.models import RidgeModel
+from alphapulse.pipeline import Pipeline
+from alphapulse.utils import set_global_seed
+
+
+class TestSetGlobalSeed:
+    def test_is_idempotent_for_numpy(self) -> None:
+        set_global_seed(42)
+        v1 = np.random.random()
+        set_global_seed(42)
+        v2 = np.random.random()
+        assert v1 == v2
+
+    def test_seeds_python_random(self) -> None:
+        set_global_seed(99)
+        v1 = random.random()
+        set_global_seed(99)
+        v2 = random.random()
+        assert v1 == v2
+
+    def test_negative_seed_raises(self) -> None:
+        with pytest.raises(ValueError, match="seed"):
+            set_global_seed(-1)
+
+    def test_zero_seed_is_valid(self) -> None:
+        set_global_seed(0)  # should not raise
+
+
+class TestRankNormalizePerEra:
+    def test_output_same_length(self) -> None:
+        preds = np.array([0.1, 0.5, 0.9, 0.2, 0.8, 0.4])
+        eras = pd.Series(["e1", "e1", "e1", "e2", "e2", "e2"])
+        out = rank_normalize_per_era(preds, eras)
+        assert len(out) == len(preds)
+
+    def test_values_in_zero_one(self) -> None:
+        preds = np.array([0.1, 0.5, 0.9, 0.2, 0.8, 0.4])
+        eras = pd.Series(["e1", "e1", "e1", "e2", "e2", "e2"])
+        out = rank_normalize_per_era(preds, eras)
+        assert np.all(out >= 0.0) and np.all(out <= 1.0)
+
+    def test_per_era_not_global(self) -> None:
+        # e1: [0.1, 0.9] → [0.0, 1.0]; e2: [0.5, 0.6] → [0.0, 1.0]
+        preds = np.array([0.1, 0.9, 0.5, 0.6])
+        eras = pd.Series(["e1", "e1", "e2", "e2"])
+        out = rank_normalize_per_era(preds, eras)
+        np.testing.assert_allclose(out[0], 0.0)
+        np.testing.assert_allclose(out[1], 1.0)
+        np.testing.assert_allclose(out[2], 0.0)
+        np.testing.assert_allclose(out[3], 1.0)
+
+    def test_differs_from_global_normalization(self) -> None:
+        preds = np.array([0.1, 0.9, 0.5, 0.6])
+        eras = pd.Series(["e1", "e1", "e2", "e2"])
+        per_era_out = rank_normalize_per_era(preds, eras)
+        global_out = rank_normalize(preds)
+        assert not np.allclose(per_era_out, global_out)
+
+    def test_mismatched_lengths_raise(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            rank_normalize_per_era(np.array([1.0, 2.0]), pd.Series(["e1"]))
+
+    def test_exported_from_evaluation_package(self) -> None:
+        from alphapulse.evaluation import rank_normalize_per_era as rnpe
+
+        assert callable(rnpe)
+
+
+class TestToNumeraiPredictColumnAlignment:
+    def _make_fitted_pipeline(self, feature_columns: list[str]) -> Pipeline:
+        rng = np.random.default_rng(0)
+        X = pd.DataFrame(
+            rng.standard_normal((30, len(feature_columns))),
+            columns=feature_columns,
+        )
+        y = pd.Series(rng.standard_normal(30))
+        pipe = Pipeline(
+            preprocessors=[], model=RidgeModel(), feature_columns=feature_columns
+        )
+        pipe.fit(X, y)
+        return pipe
+
+    def test_handles_missing_columns(self) -> None:
+        cols = ["f0", "f1", "f2"]
+        pipe = self._make_fitted_pipeline(cols)
+        predict_fn = pipe.to_numerai_predict()
+        live = pd.DataFrame({"f0": [0.1, 0.2], "f1": [0.3, 0.4]})
+        bench = pd.DataFrame({"v2": [0.5, 0.5]})
+        result = predict_fn(live, bench)
+        assert isinstance(result, pd.DataFrame)
+        assert "prediction" in result.columns
+        assert len(result) == 2
+
+    def test_handles_extra_columns(self) -> None:
+        cols = ["f0", "f1"]
+        pipe = self._make_fitted_pipeline(cols)
+        predict_fn = pipe.to_numerai_predict()
+        live = pd.DataFrame({"f0": [0.1], "f1": [0.2], "f_extra": [0.9]})
+        bench = pd.DataFrame({"v2": [0.5]})
+        result = predict_fn(live, bench)
+        assert len(result) == 1
+
+    def test_predictions_in_unit_interval(self) -> None:
+        cols = ["f0", "f1", "f2"]
+        pipe = self._make_fitted_pipeline(cols)
+        predict_fn = pipe.to_numerai_predict()
+        rng = np.random.default_rng(42)
+        live = pd.DataFrame(rng.standard_normal((50, 3)), columns=cols)
+        bench = pd.DataFrame({"v2": rng.random(50)})
+        result = predict_fn(live, bench)
+        preds = result["prediction"].to_numpy()
+        assert np.all(preds >= 0.0) and np.all(preds <= 1.0)
+
+
+class TestValidateFeatureSchema:
+    def test_warns_on_missing_columns(self) -> None:
+        cols = ["f0", "f1", "f2"]
+        pipe = Pipeline(preprocessors=[], model=RidgeModel(), feature_columns=cols)
+        X_missing = pd.DataFrame({"f0": [1.0], "f1": [2.0]})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            pipe.validate_feature_schema(X_missing)
+        assert len(w) == 1
+        assert "f2" in str(w[0].message)
+
+    def test_no_warning_on_exact_match(self) -> None:
+        cols = ["f0", "f1"]
+        pipe = Pipeline(preprocessors=[], model=RidgeModel(), feature_columns=cols)
+        X_ok = pd.DataFrame({"f0": [1.0], "f1": [2.0]})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            pipe.validate_feature_schema(X_ok)
+        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+        assert len(user_warnings) == 0
+
+    def test_no_warning_when_no_feature_columns_set(self) -> None:
+        pipe = Pipeline(preprocessors=[], model=RidgeModel(), feature_columns=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            pipe.validate_feature_schema(pd.DataFrame({"f0": [1.0]}))
+        assert len(w) == 0
+
+
+class TestBenchmarkColumnsExcluded:
+    def test_benchmark_columns_excluded_by_resolve(self) -> None:
+        from alphapulse.experiments.data import resolve_feature_columns
+
+        df = pd.DataFrame(
+            {
+                "f0": [1.0, 2.0],
+                "f1": [3.0, 4.0],
+                "v2_equivalent_return": [0.1, 0.2],
+                "era": ["e1", "e2"],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cols = resolve_feature_columns(
+                df,
+                Path(tmpdir),
+                explicit=None,
+                benchmark_columns=["v2_equivalent_return"],
+            )
+        assert "v2_equivalent_return" not in cols
+        assert "f0" in cols
+        assert "f1" in cols
+
+    def test_benchmark_columns_excluded_from_explicit(self) -> None:
+        from alphapulse.experiments.data import resolve_feature_columns
+
+        df = pd.DataFrame(
+            {
+                "f0": [1.0, 2.0],
+                "f1": [3.0, 4.0],
+                "bm": [0.1, 0.2],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cols = resolve_feature_columns(
+                df,
+                Path(tmpdir),
+                explicit=["f0", "f1", "bm"],
+                benchmark_columns=["bm"],
+            )
+        assert "bm" not in cols
+        assert "f0" in cols
+
+    def test_data_config_benchmark_columns_field(self) -> None:
+        from alphapulse.experiments.schema import DataConfig
+
+        cfg = DataConfig(
+            data_dir=Path("/tmp"),
+            benchmark_columns=["v2_equivalent_return"],
+        )
+        assert cfg.benchmark_columns == ["v2_equivalent_return"]
+
+    def test_data_config_benchmark_columns_default_empty(self) -> None:
+        from alphapulse.experiments.schema import DataConfig
+
+        cfg = DataConfig(data_dir=Path("/tmp"))
+        assert cfg.benchmark_columns == []
+
+
+class TestSmokeTestPredictFn:
+    def _write_valid_pkl(self, path: Path, feature_columns: list[str]) -> None:
+        def predict_fn(
+            live_features: pd.DataFrame,
+            live_benchmark_models: pd.DataFrame,
+        ) -> pd.DataFrame:
+            preds = rank_normalize(np.random.default_rng(0).random(len(live_features)))
+            return pd.DataFrame({"prediction": preds}, index=live_features.index)
+
+        with open(path, "wb") as f:
+            cloudpickle.dump(predict_fn, f)
+
+    def test_passes_on_valid_pkl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkl = Path(tmpdir) / "predict.pkl"
+            cols = ["f0", "f1", "f2"]
+            self._write_valid_pkl(pkl, cols)
+            smoke_test_predict_fn(pkl, cols)
+
+    def test_raises_on_corrupt_pkl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkl = Path(tmpdir) / "predict.pkl"
+            pkl.write_bytes(b"not a valid pickle")
+            with pytest.raises(RuntimeError, match="smoke_test"):
+                smoke_test_predict_fn(pkl, ["f0"])
+
+    def test_raises_when_prediction_out_of_range(self) -> None:
+        def bad_fn(
+            live_features: pd.DataFrame,
+            live_benchmark_models: pd.DataFrame,
+        ) -> pd.DataFrame:
+            return pd.DataFrame(
+                {"prediction": [2.0] * len(live_features)},
+                index=live_features.index,
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkl = Path(tmpdir) / "predict.pkl"
+            with open(pkl, "wb") as f:
+                cloudpickle.dump(bad_fn, f)
+            with pytest.raises(RuntimeError, match="smoke_test"):
+                smoke_test_predict_fn(pkl, ["f0"])
+
+    def test_raises_when_missing_prediction_column(self) -> None:
+        def bad_fn(
+            live_features: pd.DataFrame,
+            live_benchmark_models: pd.DataFrame,
+        ) -> pd.DataFrame:
+            return pd.DataFrame(
+                {"wrong_col": [0.5] * len(live_features)},
+                index=live_features.index,
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkl = Path(tmpdir) / "predict.pkl"
+            with open(pkl, "wb") as f:
+                cloudpickle.dump(bad_fn, f)
+            with pytest.raises(RuntimeError, match="smoke_test"):
+                smoke_test_predict_fn(pkl, ["f0"])
+
+    def test_tolerates_extra_feature_columns_in_live(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkl = Path(tmpdir) / "predict.pkl"
+            cols = ["f0", "f1"]
+            self._write_valid_pkl(pkl, cols)
+            smoke_test_predict_fn(pkl, cols)


### PR DESCRIPTION
## Summary

Closes 7 architectural gaps identified before the first full-dataset Numerai training run. All changes are backward-compatible (new fields have defaults, new functions are additive).

- **Global seed threading** — `utils/seed.py` with `set_global_seed()` locking numpy, Python `random`, `PYTHONHASHSEED`, and torch; called from all entry-point scripts.
- **Nested early stopping in walk-forward** — `train_fn` inside `hpo/objective.py` and `experiments/runner.py` now carves an inner validation slice via `internal_val_split` so early stopping works per fold without leaking into the test era.
- **Per-era rank normalization** — `rank_normalize_per_era()` added to `evaluation/metrics.py`, applied in `EraSplitEvaluator.evaluate_walk_forward` before `calculate_metrics`, exported from the package.
- **Feature schema contract** — `to_numerai_predict` closures in `pipeline.py` and `multihead.py` use `reindex(fill_value=0.0)` instead of bare column indexing; `Pipeline.validate_feature_schema()` emits structured warnings on missing columns.
- **OOM protection** — `load_train_frame_with_era()` now uses column-selective parquet reading (mirrors `load_train_only_frame`); `gc.collect()` added in `runner.py` post-fit.
- **Export smoke test** — `evaluation/export_validation.py` with `smoke_test_predict_fn()`; called from both export scripts after `cloudpickle.dump` to catch bundling errors early.
- **Column taxonomy** — `DataConfig.benchmark_columns: list[str]` field added; excluded from feature resolution in all three data loaders; `runner.py` passes it through.