### PR TITLE
docs: sync documentation with v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to AlphaPulse are documented here.
+
+---
+
+## [0.4.0] — Pre-Training Critical Path
+
+- **Global seed threading:** Centralized `set_global_seed()` utility invoked at script genesis — locks Python `random`, `numpy`, `torch`, and cross-validation subsampling to guarantee identical walk-forward splits across independent executions.
+- **Nested early stopping:** Each walk-forward training fold carves an inner temporal validation set (respecting purge/embargo) exclusively for loss monitoring; the outer fold remains untouched for metric reporting.
+- **Per-era rank normalization before metrics:** `rank_normalize()` enforced strictly per era (not globally) before any correlation or Sharpe computation, matching Numerai's exact scoring pipeline.
+- **Feature schema contract:** Exact ordered feature list serialised into every artifact; validated at load time — fail fast on missing columns, silently drop unexpected ones.
+- **OOM protection / lazy data loading:** Memory-mapped or streaming access for the full dataset; native `DMatrix`/`Dataset` formats for tree models to avoid 3× memory spikes during histogram construction.
+- **Export artifact smoke test:** After serialising `predict.pkl`, a clean subprocess loads it and runs a forward pass on a synthetic frame with edge-case columns — artifact marked deployment-ready only on success.
+- **Column taxonomy:** Every dataset column tagged as `feature | target | auxiliary_target | metadata | benchmark` in config; benchmark columns (e.g. `v2_equivalent_return`) bypass model training but reach the evaluation module intact.
+
+## [0.3.0] — Validation & Metrics
+
+- **Feature routing validation:** Clear error messages for `input_group` mismatches validated at YAML parse time; `HeadSpec` distinguishes undefined group vs missing columns.
+- **MMC metric tests:** Full test coverage for `mmc_score`, `per_era_mmc`, `era_sharpe_of_mmc`, and `payout_score`.
+
+## [0.2.0] — Walk-Forward Backtesting
+
+- **Purge-aware walk-forward backtesting:** `EraSplitEvaluator` with `n_purge`, `n_embargo`, `n_splits`.
+- **Consistent HPO scoring:** All trials evaluated via 3-fold walk-forward CV — no fixed holdout split.
+- **Full metric parity:** Walk-forward returns `max_drawdown`, `pct_positive_eras`, `n_valid_eras`.
+- **Ensemble diagnostics and submission validation utilities.**
+- **Per-era feature importance report.**
+
+## [0.1.0] — Initial Release
+
+- **AutoResearch Loop** with Claude agent.
+- **Foundation Models:** TabPFN, TabICL.
+- **Enhanced Model Suite:** EraEnsemble, SyntheticDataAugmenter.
+- **Multi-target and Multi-head Pipelines.**
+- **Robust NaN/inf Filtering** in Pipeline.
+- **Ensemble Weight Optimization.**
+- **Comprehensive EDA Dashboard** with HPO Analysis.
+- **Config Tooling:** `scripts/make_feature_groups.py` converts `features.json` sets into YAML `features.groups`.
+- **Unified Export:** `scripts/export_from_yaml.py` for YAML-driven production pickles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ When adding new UI text:
 - `TrainEvalPreprocessor` protocol: `train()` / `eval()` switching for noise injection
 - **Scaling:** `StandardScalerPreprocessor`, `RobustScalerPreprocessor`
 - **Dimensionality Reduction:** `PCAPreprocessor(n_components)`, `TruncatedSVDPreprocessor(n_components=10)`
-- **Feature Selection:** `VarianceFeatureSelector(keep_fraction, threshold, mode)`, `LGBMImportanceSelector(keep_fraction=0.75, n_estimators=100)`
+- **Feature Selection:** `VarianceFeatureSelector(keep_fraction, threshold, mode)`, `LGBMImportanceSelector(keep_fraction=0.75, n_estimators=100)`, `EraStableFeatureSelector(keep_fraction, n_estimators, stability_weight)` — ranks features by blended mean importance / cross-era stability score
 - **Noise Injection:** `GaussianNoiseInjector(sigma=0.01, seed=42)` — active only during `train()` mode
 - **Special:** `PackboostPreprocessor` — adds Packboost predictions as an extra feature; `GroupedPreprocessor(groups, group_preprocessors)` — applies different preprocessing chains to named feature groups
 - `PreprocessorFactory(n_features, prefix)` → Optuna-based HPO factory with `suggest(trial)` and `suggest_fixed(...)` methods
@@ -346,6 +346,21 @@ When adding new UI text:
 
 **Era Splitting** (`src/alphapulse/evaluation/era_split.py`)
 - Utilities for splitting data by era for validation
+
+**Export Validation** (`src/alphapulse/evaluation/export_validation.py`)
+- `smoke_test_predict_fn(pkl_path, feature_columns, n_rows=10)` → loads `predict.pkl` in a clean subprocess, runs a forward pass on a synthetic frame with edge-case columns, raises on any failure
+
+**Submission Validation** (`src/alphapulse/evaluation/submission.py`)
+- `validate_submission(predictions_df, live_df, id_col, pred_col)` → returns list of validation error strings; empty list means submission is well-formed
+
+**Ensemble Diagnostics** (`src/alphapulse/evaluation/ensemble_diagnostics.py`)
+- `correlation_matrix(oof_predictions, eras)` → per-era inter-model Spearman correlation matrix; high correlation means ensemble gains little over a single model
+
+**Feature Report** (`src/alphapulse/evaluation/feature_report.py`)
+- `compute_feature_report(X, y, eras)` → per-era feature importance diagnostics; tracks mean importance and cross-era stability
+
+**Global Seed Utility** (`src/alphapulse/utils/seed.py`)
+- `set_global_seed(seed)` → locks Python `random`, NumPy, PyTorch (if available), and sets `PYTHONHASHSEED` so child processes (e.g. Ray workers) inherit a fixed hash seed
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AlphaPulse
-0.1.0 (internal release)
+0.4.0
 
 AlphaPulse is a config-driven framework for building, training, and deploying Numerai competition pipelines.
 
@@ -539,17 +539,14 @@ Commit messages: prefer conventional commits (e.g. `feat: ...`, `fix: ...`, `doc
 - ✅ Validation: clear error messages for feature routing mismatches (`input_group` validated at YAML parse time; `HeadSpec` distinguishes undefined group vs missing columns)
 - ✅ MMC metric tests: full test coverage for `mmc_score`, `per_era_mmc`, `era_sharpe_of_mmc`, and `payout_score`
 
-**Upcoming — v0.4.0 (Pre-Training Critical Path):**
-
-*Must be resolved before the first serious full-dataset training run.*
-
-1. **Global seed threading:** Centralized `set_global_seed()` utility invoked at script genesis — locks Python `random`, `numpy`, `torch`, and cross-validation subsampling to guarantee identical walk-forward splits across independent executions.
-2. **Nested early stopping:** Decouple early-stopping validation from the outer holdout fold. Each walk-forward training fold must carve an inner temporal validation set (respecting purge/embargo) exclusively for loss monitoring; the outer fold remains untouched for metric reporting.
-3. **Per-era rank normalization before metrics:** Enforce `rank_normalize()` strictly per era (not globally) before any correlation or Sharpe computation, matching Numerai's exact scoring pipeline.
-4. **Feature schema contract:** Serialise the exact ordered feature list into every artifact; validate incoming data against it at load time — fail fast on missing columns, silently drop unexpected ones.
-5. **OOM protection / lazy data loading:** Transition from full in-memory loading to memory-mapped or streaming access for the full dataset; use native `DMatrix`/`Dataset` formats for tree models to avoid 3× memory spikes during histogram construction.
-6. **Export artifact smoke test:** After serialising `predict.pkl`, spawn a clean subprocess that loads it and runs a forward pass on a synthetic frame with edge-case columns — only mark the artifact as deployment-ready on success.
-7. **Column taxonomy:** Tag every dataset column as `feature | target | auxiliary_target | metadata | benchmark` in config; guarantee benchmark columns (e.g. `v2_equivalent_return`) bypass model training but reach the evaluation module intact.
+**Completed in v0.4.0 (Pre-Training Critical Path):**
+- ✅ **Global seed threading:** Centralized `set_global_seed()` utility invoked at script genesis — locks Python `random`, `numpy`, `torch`, and cross-validation subsampling to guarantee identical walk-forward splits across independent executions.
+- ✅ **Nested early stopping:** Decouple early-stopping validation from the outer holdout fold. Each walk-forward training fold carves an inner temporal validation set (respecting purge/embargo) exclusively for loss monitoring; the outer fold remains untouched for metric reporting.
+- ✅ **Per-era rank normalization before metrics:** Enforce `rank_normalize()` strictly per era (not globally) before any correlation or Sharpe computation, matching Numerai's exact scoring pipeline.
+- ✅ **Feature schema contract:** Serialise the exact ordered feature list into every artifact; validate incoming data against it at load time — fail fast on missing columns, silently drop unexpected ones.
+- ✅ **OOM protection / lazy data loading:** Transition from full in-memory loading to memory-mapped or streaming access for the full dataset; use native `DMatrix`/`Dataset` formats for tree models to avoid 3× memory spikes during histogram construction.
+- ✅ **Export artifact smoke test:** After serialising `predict.pkl`, spawn a clean subprocess that loads it and runs a forward pass on a synthetic frame with edge-case columns — only mark the artifact as deployment-ready on success.
+- ✅ **Column taxonomy:** Tag every dataset column as `feature | target | auxiliary_target | metadata | benchmark` in config; guarantee benchmark columns (e.g. `v2_equivalent_return`) bypass model training but reach the evaluation module intact.
 
 **Upcoming — v0.5.0 (Production Hardening):**
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,8 @@ eda/
 └── utils/                  # Utilities
     ├── config.py           # Path resolution and constants
     ├── data_loader.py      # NumeraiDataLoader wrapper
-    ├── i18n.py             # Translation helper
+    ├── translations.py     # YAML-based translation system
+    ├── i18n.py             # Translation helper (session state access)
     └── common.py           # Shared analysis utilities
 ```
 
@@ -488,6 +489,10 @@ make eda-lint
 │   ├── hpo_pipeline.py
 │   ├── run_test_pipeline.py
 │   ├── export_numerai_pickle.py
+│   ├── export_from_yaml.py
+│   ├── live_inference.py
+│   ├── submit_predictions.py
+│   ├── make_feature_groups.py
 │   └── autoresearch.py
 ├── eda/             # Standalone Streamlit EDA dashboard
 │   ├── app.py         # Main entry point (streamlit run eda/app.py)
@@ -495,8 +500,15 @@ make eda-lint
 │   └── utils/         # Config & data loading (uses NumeraiDataLoader)
 ├── src/alphapulse/  # Core framework source code
 │   ├── autoresearch/  # Agent-driven research loop
+│   ├── evaluation/    # Backtesting, metrics, diagnostics, export validation
+│   ├── experiments/   # YAML schema, runner, data loading
+│   ├── hpo/           # HPO objective, search space, builder, registry
 │   ├── logging_/      # Leaderboard and W&B helpers
-│   └── ...            # pipeline, models, hpo, experiments, etc.
+│   ├── models/        # All model implementations + factory
+│   ├── pipeline/      # Pipeline, ensemble, neutralizer, stacker
+│   ├── preprocessors/ # All preprocessor implementations + factory
+│   ├── utils/         # Seed utility (set_global_seed)
+│   └── validation/    # Purged era cross-validation
 └── tests/           # Unit tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -517,46 +517,16 @@ Commit messages: prefer conventional commits (e.g. `feat: ...`, `fix: ...`, `doc
 
 ## Roadmap
 
-**Completed in v0.1.0:**
-- ✅ AutoResearch Loop with Claude agent
-- ✅ Foundation Models (TabPFN, TabICL)
-- ✅ Enhanced Model Suite (EraEnsemble, SyntheticDataAugmenter)
-- ✅ Multi-target and Multi-head Pipelines
-- ✅ Robust NaN/inf Filtering in Pipeline
-- ✅ Ensemble Weight Optimization
-- ✅ Comprehensive EDA Dashboard with HPO Analysis
-- ✅ Config Tooling: `scripts/make_feature_groups.py` converts `features.json` sets into YAML `features.groups`
-- ✅ Unified Export: `scripts/export_from_yaml.py` for YAML-driven production pickles
-
-**Completed in v0.2.0:**
-- ✅ Purge-aware walk-forward backtesting (`EraSplitEvaluator` with `n_purge`, `n_embargo`, `n_splits`)
-- ✅ Consistent HPO scoring: all trials evaluated via 3-fold walk-forward CV (no fixed holdout split)
-- ✅ Full metric parity: walk-forward returns `max_drawdown`, `pct_positive_eras`, `n_valid_eras`
-- ✅ Ensemble diagnostics and submission validation utilities
-- ✅ Per-era feature importance report
-
-**Completed in v0.3.0:**
-- ✅ Validation: clear error messages for feature routing mismatches (`input_group` validated at YAML parse time; `HeadSpec` distinguishes undefined group vs missing columns)
-- ✅ MMC metric tests: full test coverage for `mmc_score`, `per_era_mmc`, `era_sharpe_of_mmc`, and `payout_score`
-
-**Completed in v0.4.0 (Pre-Training Critical Path):**
-- ✅ **Global seed threading:** Centralized `set_global_seed()` utility invoked at script genesis — locks Python `random`, `numpy`, `torch`, and cross-validation subsampling to guarantee identical walk-forward splits across independent executions.
-- ✅ **Nested early stopping:** Decouple early-stopping validation from the outer holdout fold. Each walk-forward training fold carves an inner temporal validation set (respecting purge/embargo) exclusively for loss monitoring; the outer fold remains untouched for metric reporting.
-- ✅ **Per-era rank normalization before metrics:** Enforce `rank_normalize()` strictly per era (not globally) before any correlation or Sharpe computation, matching Numerai's exact scoring pipeline.
-- ✅ **Feature schema contract:** Serialise the exact ordered feature list into every artifact; validate incoming data against it at load time — fail fast on missing columns, silently drop unexpected ones.
-- ✅ **OOM protection / lazy data loading:** Transition from full in-memory loading to memory-mapped or streaming access for the full dataset; use native `DMatrix`/`Dataset` formats for tree models to avoid 3× memory spikes during histogram construction.
-- ✅ **Export artifact smoke test:** After serialising `predict.pkl`, spawn a clean subprocess that loads it and runs a forward pass on a synthetic frame with edge-case columns — only mark the artifact as deployment-ready on success.
-- ✅ **Column taxonomy:** Tag every dataset column as `feature | target | auxiliary_target | metadata | benchmark` in config; guarantee benchmark columns (e.g. `v2_equivalent_return`) bypass model training but reach the evaluation module intact.
+See [CHANGELOG.md](CHANGELOG.md) for completed releases.
 
 **Upcoming — v0.5.0 (Production Hardening):**
-
-8. **HPO fault tolerance:** Back the optimization sweep with a persistent trial database; isolate each trial in a subprocess so a crash marks that trial failed and the sweep continues; checkpoint deep-learning weights per epoch.
-9. **Provenance artifact:** On every successful trial, save a hermetically sealed bundle: resolved config, `uv export` dependency snapshot, and the git commit hash — verify the environment on resume/deploy.
-10. **Canonical artifact naming:** Enforce `<TIMESTAMP>_<ARCH>_<TARGET>_<CONFIG_HASH>.pkl` for all exported models to prevent overwrite collisions and enable automated deployment selection.
-11. **Masked loss for auxiliary targets:** Implement per-column boolean masking in multi-task neural losses so `NaN`-sparse auxiliary targets contribute valid gradients without crashing backpropagation.
-12. **Feature neutralization in eval loop:** Project predictions orthogonally to the Numerai Neutralizers Matrix before computing selection metrics, rewarding genuinely novel alpha over crowded factor exposure.
-13. **W&B Integration:** Full experiment tracking — co-locate configs, per-era metrics, and artifacts in a searchable run database (config scaffolding already exists).
-14. **CI/CD:** Automated weekly submission pipeline with GitHub Actions (download → infer → submit).
+- **HPO fault tolerance:** Back the optimization sweep with a persistent trial database; isolate each trial in a subprocess so a crash marks that trial failed and the sweep continues; checkpoint deep-learning weights per epoch.
+- **Provenance artifact:** On every successful trial, save a hermetically sealed bundle: resolved config, `uv export` dependency snapshot, and the git commit hash — verify the environment on resume/deploy.
+- **Canonical artifact naming:** Enforce `<TIMESTAMP>_<ARCH>_<TARGET>_<CONFIG_HASH>.pkl` for all exported models to prevent overwrite collisions and enable automated deployment selection.
+- **Masked loss for auxiliary targets:** Implement per-column boolean masking in multi-task neural losses so `NaN`-sparse auxiliary targets contribute valid gradients without crashing backpropagation.
+- **Feature neutralization in eval loop:** Project predictions orthogonally to the Numerai Neutralizers Matrix before computing selection metrics, rewarding genuinely novel alpha over crowded factor exposure.
+- **W&B Integration:** Full experiment tracking — co-locate configs, per-era metrics, and artifacts in a searchable run database (config scaffolding already exists).
+- **CI/CD:** Automated weekly submission pipeline with GitHub Actions (download → infer → submit).
 
 -----
 

--- a/src/alphapulse/__about__.py
+++ b/src/alphapulse/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present jakub.szulc <szulcak05@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary

- Creates `CHANGELOG.md` with all completed releases (v0.1.0–v0.4.0), keeping the roadmap section in README forward-looking only
- Bumps `__about__.py` version from `0.1.0` to `0.4.0`
- Expands README directory structure to reflect current codebase (all `src/alphapulse/` submodules, full scripts list, both EDA utils files)
- Syncs CLAUDE.md with v0.4.0 additions: `EraStableFeatureSelector`, four new evaluation modules (`export_validation`, `submission`, `ensemble_diagnostics`, `feature_report`), and `utils/seed.py` (`set_global_seed`)

## Test plan

- [ ] Verify `CHANGELOG.md` covers all releases accurately
- [ ] Verify README directory structure matches `ls scripts/` and `ls src/alphapulse/`
- [ ] Verify `__version__` in `__about__.py` matches the roadmap milestone
- [ ] Verify CLAUDE.md entries match actual module signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)