### PR TITLE
GPU HPO, foundation models, neutralization and WandB XAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ __marimo__/
 # AlphaPulse-specific
 artifacts/
 data/
+wandb/
+catboost_info/

--- a/experiments/example_v1.yaml
+++ b/experiments/example_v1.yaml
@@ -24,6 +24,8 @@ models:
         eval_metric: rmse
 ensemble_method: single
 ensemble_params: {}
+neutralization:
+  proportion: 0.35
 train:
   n_rounds: 40
   early_stopping_rounds: 5

--- a/experiments/foundation_v1.yaml
+++ b/experiments/foundation_v1.yaml
@@ -1,0 +1,33 @@
+# Foundation model experiment — compress 780 features via VAE/autoencoder before TabICL/TabPFN.
+version: "1"
+data:
+  data_dir: data/v5.2
+  train_subsample: 1.0
+  target_col: target
+  seed: 42
+features:
+  columns: null
+  groups: {}
+preprocessing:
+  - type: StandardScaler
+    params: {}
+models:
+  - type: TabICL
+    params:
+      n_estimators: 4
+      max_train_rows: 8000
+      compression: autoencoder
+      compression_components: 128
+      compression_epochs: 10
+      kv_cache: false
+      batch_size: 8
+ensemble_method: single
+ensemble_params: {}
+neutralization:
+  proportion: 0.0
+train:
+  n_rounds: 1
+  early_stopping_rounds: 1
+evaluation:
+  primary_metric: corr_sharpe
+  walk_forward: false

--- a/experiments/gpu_v1.yaml
+++ b/experiments/gpu_v1.yaml
@@ -23,6 +23,8 @@ models:
         device: cuda
 ensemble_method: single
 ensemble_params: {}
+neutralization:
+  proportion: 0.35
 train:
   n_rounds: 500
   early_stopping_rounds: 50

--- a/experiments/gpu_v1.yaml
+++ b/experiments/gpu_v1.yaml
@@ -1,0 +1,31 @@
+# Experiment v1 — GPU-enabled XGBoost with CUDA device.
+version: "1"
+data:
+  data_dir: data/v5.2
+  train_subsample: 0.05
+  target_col: target
+  seed: 42
+features:
+  columns: null
+  groups: {}
+preprocessing:
+  - type: StandardScaler
+    params: {}
+models:
+  - type: XGBoost
+    params:
+      params:
+        max_depth: 5
+        learning_rate: 0.01
+        tree_method: hist
+        objective: reg:squarederror
+        eval_metric: rmse
+        device: cuda
+ensemble_method: single
+ensemble_params: {}
+train:
+  n_rounds: 500
+  early_stopping_rounds: 50
+evaluation:
+  primary_metric: corr_sharpe
+  walk_forward: false

--- a/scripts/autoresearch.py
+++ b/scripts/autoresearch.py
@@ -90,6 +90,7 @@ def main(
         agent_model=agent_model,
         resume=resume,
         wandb_project=wandb_project,
+        data_dir=data_dir,
     )
 
     n_ok = sum(1 for t in state.trials if t.error is None)

--- a/scripts/gpu_smoke_test.py
+++ b/scripts/gpu_smoke_test.py
@@ -1,0 +1,85 @@
+"""Smoke-test GPU training for XGBoost, LightGBM, and CatBoost via AlphaPulse."""
+
+from __future__ import annotations
+
+import multiprocessing
+import sys
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from alphapulse.hpo.builder import instantiate_model
+from alphapulse.hpo.search_space import apply_gpu_model_params
+from alphapulse.models.era_ensemble_model import EraEnsembleModel
+
+
+def _synthetic_frame(n: int = 3000, p: int = 15) -> tuple[pd.DataFrame, pd.Series]:
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((n, p)), columns=[f"f{i}" for i in range(p)])
+    y = pd.Series(rng.standard_normal(n))
+    return X, y
+
+
+def _train_model(model_type: str, n_rounds: int = 40) -> dict[str, Any]:
+    X, y = _synthetic_frame()
+    params = apply_gpu_model_params(model_type, {"params": {}})
+    model = instantiate_model(model_type, params, index=0, n_subs=1)
+    if not isinstance(model, EraEnsembleModel):
+        raise TypeError(f"Expected EraEnsembleModel for {model_type}")
+    base = model.base_model_factory()
+    metrics = base.train(X, y, n_rounds=n_rounds)
+    preds = base.predict(X.iloc[:10])
+    return {"model": model_type, "metrics": metrics, "pred_shape": preds.shape}
+
+
+def _spawn_worker(model_type: str, result_queue: multiprocessing.Queue[dict]) -> None:
+    try:
+        result_queue.put({"ok": True, "result": _train_model(model_type)})
+    except Exception as exc:
+        result_queue.put({"ok": False, "model": model_type, "error": str(exc)})
+
+
+def main() -> int:
+    print("=== AlphaPulse GPU integration smoke test ===\n")
+    failures: list[str] = []
+
+    for model_type in ("XGBoost", "LightGBM", "CatBoost"):
+        try:
+            result = _train_model(model_type)
+            print(f"[in-process] {model_type}: OK  pred_shape={result['pred_shape']}")
+        except Exception as exc:
+            failures.append(f"{model_type} in-process: {exc}")
+            print(f"[in-process] {model_type}: FAIL  {exc}")
+
+    ctx = multiprocessing.get_context("spawn")
+    for model_type in ("XGBoost", "LightGBM", "CatBoost"):
+        queue: multiprocessing.Queue[dict] = ctx.Queue()
+        proc = ctx.Process(target=_spawn_worker, args=(model_type, queue))
+        proc.start()
+        proc.join(timeout=120)
+        if proc.is_alive():
+            proc.kill()
+            failures.append(f"{model_type} spawn: timeout")
+            print(f"[spawn] {model_type}: TIMEOUT")
+            continue
+        payload = queue.get()
+        if payload.get("ok"):
+            shape = payload["result"]["pred_shape"]
+            print(f"[spawn] {model_type}: OK  pred_shape={shape}")
+        else:
+            failures.append(f"{model_type} spawn: {payload.get('error')}")
+            print(f"[spawn] {model_type}: FAIL  {payload.get('error')}")
+
+    if failures:
+        print("\nFailures:")
+        for item in failures:
+            print(f"  - {item}")
+        return 1
+
+    print("\nAll GPU smoke tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Literal
 
 import tyro
+from dotenv import load_dotenv
 from loguru import logger
 
 from alphapulse.experiments.data import load_train_only_frame
@@ -43,9 +44,49 @@ def _trial_worker(
     target_col: str,
     seed: int,
     result_queue: "multiprocessing.Queue[dict]",
+    *,
+    wandb_project: str | None = None,
+    wandb_group: str | None = None,
+    trial_number: int | None = None,
+    wandb_diagnostics: bool = True,
 ) -> None:
     """Run a single trial inside a subprocess and push the result to the queue."""
     try:
+        load_dotenv()
+        worker_config = dict(flat_config)
+        wandb_active = (
+            wandb_project is not None
+            and wandb_group is not None
+            and trial_number is not None
+        )
+        if wandb_active:
+            worker_config["log_wandb_diagnostics"] = wandb_diagnostics
+            worker_config["wandb_log_shap"] = wandb_diagnostics
+            import wandb
+
+            from alphapulse.hpo.objective import TrialResult
+            from alphapulse.logging_.wandb_utils import log_hpo_trial_metrics
+
+            num = flat_config.get("num_models", 1)
+            model_types = "+".join(
+                str(flat_config.get(f"model_{i}_type", "?")) for i in range(1, num + 1)
+            )
+            preprocessors = flat_config.get("scaler_type", "StandardScaler")
+            if flat_config.get("use_packboost"):
+                preprocessors += "+Packboost"
+            wandb.init(
+                project=wandb_project,
+                group=wandb_group,
+                name=f"trial_{trial_number:03d}",
+                config={
+                    **flat_config,
+                    "model_types": model_types,
+                    "preprocessors": preprocessors,
+                },
+                reinit=True,
+            )
+
+        t0 = time.perf_counter()
         X_train, y_train, feature_cols = load_train_only_frame(
             Path(data_dir),
             train_subsample=train_subsample,
@@ -56,14 +97,36 @@ def _trial_worker(
         )
         era_train = X_train["era"]
         metrics = run_trial(
-            flat_config,
+            worker_config,
             X_train=X_train,
             y_train=y_train,
             era_train=era_train,
             feature_cols=feature_cols,
             seed=seed,
         )
-        result_queue.put({"ok": True, "metrics": metrics})
+        elapsed = time.perf_counter() - t0
+        if wandb_active:
+            corr_sharpe = float(metrics.get("corr_sharpe", float("-inf")))
+            trial_result = TrialResult(
+                trial_number=int(trial_number),
+                sharpe=corr_sharpe,
+                metrics=metrics,
+                model_type=str(flat_config.get("model_1_type", "XGBoost")),
+                elapsed_seconds=elapsed,
+                params=flat_config,
+                corr_sharpe=corr_sharpe,
+            )
+            log_hpo_trial_metrics(
+                trial_result,
+                corr_sharpe,
+                model_types=model_types,
+                preprocessors=preprocessors,
+            )
+            import wandb
+
+            wandb.finish(quiet=True)
+
+        result_queue.put({"ok": True, "metrics": metrics, "elapsed_seconds": elapsed})
     except Exception as exc:
         result_queue.put({"ok": False, "error": str(exc)})
 
@@ -96,6 +159,7 @@ def _run_local(
     trial_timeout: int = 1800,
     gpu: bool = False,
     fast: bool = True,
+    wandb_diagnostics: bool = True,
 ) -> None:
     """Local random-search HPO with subprocess isolation and SQLite trial DB."""
 
@@ -118,7 +182,10 @@ def _run_local(
     wandb_group = f"hpo-{uuid.uuid4().hex[:8]}" if wandb_project else None
     if wandb_project:
         logger.info(
-            "WandB logging enabled: project={} group={}", wandb_project, wandb_group
+            "WandB logging enabled: project={} group={} diagnostics={}",
+            wandb_project,
+            wandb_group,
+            wandb_diagnostics,
         )
 
     trial_kwargs = {
@@ -173,14 +240,18 @@ def _run_local(
             result_queue: multiprocessing.Queue = _MP_CTX.Queue()
             p = _MP_CTX.Process(
                 target=_trial_worker,
-                args=(
-                    flat_config,
-                    trial_kwargs["data_dir"],
-                    trial_kwargs["train_subsample"],
-                    trial_kwargs["target_col"],
-                    seed + i,
-                    result_queue,
-                ),
+                kwargs={
+                    "flat_config": flat_config,
+                    "data_dir": trial_kwargs["data_dir"],
+                    "train_subsample": trial_kwargs["train_subsample"],
+                    "target_col": trial_kwargs["target_col"],
+                    "seed": seed + i,
+                    "result_queue": result_queue,
+                    "wandb_project": wandb_project,
+                    "wandb_group": wandb_group,
+                    "trial_number": i,
+                    "wandb_diagnostics": wandb_diagnostics,
+                },
             )
             p.start()
             p.join(timeout=trial_timeout)
@@ -231,12 +302,15 @@ def _run_local(
                     metrics = payload["metrics"]
                     corr_sharpe = metrics.get("corr_sharpe", float("-inf"))
                     trial_score = float(metrics.get(objective, corr_sharpe))
+                    worker_elapsed = payload.get("elapsed_seconds")
                     result = TrialResult(
                         trial_number=i,
                         sharpe=corr_sharpe,
                         metrics=metrics,
                         model_type=flat_config.get("model_1_type", "XGBoost"),
-                        elapsed_seconds=elapsed,
+                        elapsed_seconds=float(worker_elapsed)
+                        if worker_elapsed is not None
+                        else elapsed,
                         params=flat_config,
                         corr_sharpe=corr_sharpe,
                     )
@@ -277,7 +351,12 @@ def _run_local(
                 current_trial=i,
             )
 
-            if wandb_project and wandb_group and not result.error:
+            if (
+                wandb_project
+                and wandb_group
+                and not result.error
+                and not wandb_diagnostics
+            ):
                 from alphapulse.logging_.wandb_utils import log_hpo_trial
 
                 log_hpo_trial(
@@ -448,12 +527,16 @@ def main(
     trial_timeout: int = 1800,
     gpu: bool = False,
     fast: bool = True,
+    wandb_diagnostics: bool = True,
 ) -> None:
     """Run HPO search over preprocessing, models, and ensemble strategies.
 
     Use --local for random search without Ray, or omit for Ray Tune.
     Use --objective to choose the optimization target (default: corr_sharpe).
     Pass --wandb-project <name> to log every trial to Weights & Biases.
+    With WandB enabled, diagnostics (per-era charts, feature exposure, SHAP
+    for XGBoost) are logged under the ``diagnostics/`` prefix in each trial run.
+    Pass --no-wandb-diagnostics to log metrics only.
     Pass --resume to continue an interrupted sweep (requires --local).
     Pass --trial-timeout N to cap each subprocess trial at N seconds (default: 1800).
     Pass --gpu to enable CUDA for XGBoost, LightGBM, and CatBoost.
@@ -461,6 +544,7 @@ def main(
     finish within ~30 minutes on full data.
     Pass --no-fast for full walk-forward evaluation (slower).
     """
+    load_dotenv()
     set_global_seed(seed)
     if local:
         _run_local(
@@ -476,6 +560,7 @@ def main(
             trial_timeout=trial_timeout,
             gpu=gpu,
             fast=fast,
+            wandb_diagnostics=wandb_diagnostics,
         )
     else:
         _run_ray(

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -33,15 +33,36 @@ from alphapulse.logging_.leaderboard import (
 )
 from alphapulse.utils import set_global_seed
 
+_MP_CTX = multiprocessing.get_context("spawn")
+
 
 def _trial_worker(
     flat_config: dict,
-    trial_kwargs: dict,
+    data_dir: str,
+    train_subsample: float,
+    target_col: str,
+    seed: int,
     result_queue: "multiprocessing.Queue[dict]",
 ) -> None:
     """Run a single trial inside a subprocess and push the result to the queue."""
     try:
-        metrics = run_trial(flat_config, **trial_kwargs)
+        X_train, y_train, feature_cols = load_train_only_frame(
+            Path(data_dir),
+            train_subsample=train_subsample,
+            target_col=target_col,
+            seed=seed,
+            feature_columns=None,
+            need_era=True,
+        )
+        era_train = X_train["era"]
+        metrics = run_trial(
+            flat_config,
+            X_train=X_train,
+            y_train=y_train,
+            era_train=era_train,
+            feature_cols=feature_cols,
+            seed=seed,
+        )
         result_queue.put({"ok": True, "metrics": metrics})
     except Exception as exc:
         result_queue.put({"ok": False, "error": str(exc)})
@@ -85,7 +106,6 @@ def _run_local(
         feature_columns=None,
         need_era=True,
     )
-    era_train = X_train["era"]
     logger.info(
         "Data loaded: train={}, features={}",
         X_train.shape,
@@ -101,10 +121,9 @@ def _run_local(
         )
 
     trial_kwargs = {
-        "X_train": X_train,
-        "y_train": y_train,
-        "era_train": era_train,
-        "feature_cols": feature_cols,
+        "data_dir": str(data_dir),
+        "train_subsample": train_subsample,
+        "target_col": target_col,
     }
 
     results: list[TrialResult] = []
@@ -140,10 +159,17 @@ def _run_local(
             db.insert_trial(i, flat_config)
 
             t0 = time.perf_counter()
-            result_queue: multiprocessing.Queue = multiprocessing.Queue()
-            p = multiprocessing.Process(
+            result_queue: multiprocessing.Queue = _MP_CTX.Queue()
+            p = _MP_CTX.Process(
                 target=_trial_worker,
-                args=(flat_config, {**trial_kwargs, "seed": seed + i}, result_queue),
+                args=(
+                    flat_config,
+                    trial_kwargs["data_dir"],
+                    trial_kwargs["train_subsample"],
+                    trial_kwargs["target_col"],
+                    seed + i,
+                    result_queue,
+                ),
             )
             p.start()
             p.join(timeout=trial_timeout)

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -35,6 +35,40 @@ from alphapulse.logging_.leaderboard import (
 from alphapulse.utils import set_global_seed
 
 _MP_CTX = multiprocessing.get_context("spawn")
+_WANDB_GROUP_FILE = "wandb_group.txt"
+
+
+def _load_or_create_wandb_group(
+    output_dir: Path, wandb_project: str | None
+) -> str | None:
+    if not wandb_project:
+        return None
+    path = output_dir / _WANDB_GROUP_FILE
+    if path.exists():
+        return path.read_text(encoding="utf-8").strip()
+    group = f"hpo-{uuid.uuid4().hex[:8]}"
+    path.write_text(group, encoding="utf-8")
+    return group
+
+
+def _trial_result_from_db_row(row: dict) -> TrialResult:
+    metrics = row["metrics"] or {}
+    corr_sharpe = float(metrics.get("corr_sharpe", float("-inf")))
+    flat_config = row["flat_config"]
+    return TrialResult(
+        trial_number=int(row["trial_number"]),
+        sharpe=corr_sharpe,
+        metrics=metrics,
+        model_type=str(flat_config.get("model_1_type", "XGBoost")),
+        elapsed_seconds=float(row["elapsed_seconds"] or 0.0),
+        params=flat_config,
+        error=row["error"],
+        corr_sharpe=corr_sharpe,
+    )
+
+
+def _all_results_from_db(db: TrialDB) -> list[TrialResult]:
+    return [_trial_result_from_db_row(row) for row in db.load_all_trials()]
 
 
 def _trial_worker(
@@ -51,6 +85,7 @@ def _trial_worker(
     wandb_diagnostics: bool = True,
 ) -> None:
     """Run a single trial inside a subprocess and push the result to the queue."""
+    wandb_initialized = False
     try:
         load_dotenv()
         worker_config = dict(flat_config)
@@ -85,6 +120,7 @@ def _trial_worker(
                 },
                 reinit=True,
             )
+            wandb_initialized = True
 
         t0 = time.perf_counter()
         X_train, y_train, feature_cols = load_train_only_frame(
@@ -105,10 +141,11 @@ def _trial_worker(
             seed=seed,
         )
         elapsed = time.perf_counter() - t0
-        if wandb_active:
+        if wandb_initialized:
+            assert trial_number is not None
             corr_sharpe = float(metrics.get("corr_sharpe", float("-inf")))
             trial_result = TrialResult(
-                trial_number=int(trial_number),
+                trial_number=trial_number,
                 sharpe=corr_sharpe,
                 metrics=metrics,
                 model_type=str(flat_config.get("model_1_type", "XGBoost")),
@@ -122,13 +159,15 @@ def _trial_worker(
                 model_types=model_types,
                 preprocessors=preprocessors,
             )
-            import wandb
-
-            wandb.finish(quiet=True)
 
         result_queue.put({"ok": True, "metrics": metrics, "elapsed_seconds": elapsed})
     except Exception as exc:
         result_queue.put({"ok": False, "error": str(exc)})
+    finally:
+        if wandb_initialized:
+            import wandb
+
+            wandb.finish(quiet=True)
 
 
 def _best_from_db(db: TrialDB, objective: str) -> tuple[float, dict]:
@@ -179,7 +218,7 @@ def _run_local(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     db_path = output_dir / "trials.db"
-    wandb_group = f"hpo-{uuid.uuid4().hex[:8]}" if wandb_project else None
+    wandb_group = _load_or_create_wandb_group(output_dir, wandb_project)
     if wandb_project:
         logger.info(
             "WandB logging enabled: project={} group={} diagnostics={}",
@@ -347,7 +386,7 @@ def _run_local(
             )
             print_leaderboard(
                 logger,
-                [entry_from_hpo_result(r) for r in results],
+                [entry_from_hpo_result(r) for r in _all_results_from_db(db)],
                 current_trial=i,
             )
 
@@ -372,6 +411,7 @@ def _run_local(
                 best_config = flat_config
 
         best_score, best_config = _best_from_db(db, objective)
+        results = _all_results_from_db(db)
 
     best_path = output_dir / "best_config.json"
     with open(best_path, "w", encoding="utf-8") as f:

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -17,15 +17,14 @@ import multiprocessing
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
-import pandas as pd
 import tyro
 from loguru import logger
 
 from alphapulse.experiments.data import load_train_only_frame
 from alphapulse.hpo.objective import TrialResult, run_trial
-from alphapulse.hpo.search_space import FOUNDATION_MODELS, sample_random_config
+from alphapulse.hpo.search_space import sample_random_config
 from alphapulse.hpo.trial_db import TrialDB
 from alphapulse.logging_.leaderboard import (
     entry_from_hpo_result,
@@ -48,71 +47,18 @@ def _trial_worker(
         result_queue.put({"ok": False, "error": str(exc)})
 
 
-def _probe_model_worker(
-    model_type: str,
-    X: pd.DataFrame,
-    y: pd.Series,
-    q: "multiprocessing.Queue[dict[str, Any]]",
-) -> None:
-    try:
-        from alphapulse.hpo.registry import MODEL_REGISTRY
-
-        cls, defaults = MODEL_REGISTRY[model_type]
-        model = cls(**defaults)
-        model.train(X, y)
-        model.predict(X.iloc[:5])
-        q.put({"ok": True})
-    except Exception as exc:
-        q.put({"ok": False, "error": str(exc)})
-
-
-def _probe_foundation_models(
-    X_train: pd.DataFrame, y_train: pd.Series, timeout: int = 60
-) -> frozenset[str]:
-    """Smoke-test each foundation model on a tiny sample.
-
-    Returns the set of model names that failed or timed out.
-    These will be excluded from the HPO search space.
-    """
-    n = min(500, len(X_train))
-    X_sample = X_train.iloc[:n].copy()
-    y_sample = y_train.iloc[:n].copy()
-
-    excluded: set[str] = set()
-    for model_type in FOUNDATION_MODELS:
-        logger.info("Probing foundation model: {}", model_type)
-        q: multiprocessing.Queue = multiprocessing.Queue()
-        p = multiprocessing.Process(
-            target=_probe_model_worker,
-            args=(model_type, X_sample, y_sample, q),
-        )
-        p.start()
-        p.join(timeout=timeout)
-
-        if p.is_alive():
-            p.terminate()
-            p.join(timeout=5)
-            if p.is_alive():
-                p.kill()
-                p.join()
-            excluded.add(model_type)
-            logger.warning(
-                "  {} timed out after {}s — excluded from HPO", model_type, timeout
-            )
-        else:
-            result: dict[str, Any] = (
-                q.get_nowait() if not q.empty() else {"ok": False, "error": "no result"}
-            )
-            if result.get("ok"):
-                logger.info("  {} OK — included in HPO", model_type)
-            else:
-                excluded.add(model_type)
-                logger.warning(
-                    "  {} failed: {} — excluded from HPO",
-                    model_type,
-                    result.get("error", "unknown"),
-                )
-    return frozenset(excluded)
+def _best_from_db(db: TrialDB, objective: str) -> tuple[float, dict]:
+    best_score = float("-inf")
+    best_config: dict = {}
+    for row in db.load_all_trials():
+        if row["status"] != "completed" or not row["metrics"]:
+            continue
+        metrics = row["metrics"]
+        score = float(metrics.get(objective, metrics.get("corr_sharpe", float("-inf"))))
+        if score > best_score:
+            best_score = score
+            best_config = row["flat_config"]
+    return best_score, best_config
 
 
 def _run_local(
@@ -127,6 +73,7 @@ def _run_local(
     wandb_project: str | None = None,
     resume: bool = False,
     trial_timeout: int = 1800,
+    gpu: bool = False,
 ) -> None:
     """Local random-search HPO with subprocess isolation and SQLite trial DB."""
 
@@ -144,13 +91,6 @@ def _run_local(
         X_train.shape,
         len(feature_cols),
     )
-
-    logger.info("Probing foundation models on 500-row sample (timeout=60s each)...")
-    exclude_models = _probe_foundation_models(X_train, y_train, timeout=60)
-    if exclude_models:
-        logger.info("Excluded from HPO: {}", sorted(exclude_models))
-    else:
-        logger.info("All foundation models passed — none excluded")
 
     output_dir.mkdir(parents=True, exist_ok=True)
     db_path = output_dir / "trials.db"
@@ -173,6 +113,15 @@ def _run_local(
 
     with TrialDB(db_path) as db:
         already_done = db.completed_trials() if resume else set()
+        if resume:
+            best_score, best_config = _best_from_db(db, objective)
+            if best_config:
+                logger.info(
+                    "Resuming: global best {}={:.4f} from {} completed trial(s)",
+                    objective,
+                    best_score,
+                    len(already_done),
+                )
         if resume and already_done:
             logger.info(
                 "Resuming: {} trial(s) already completed, skipping.", len(already_done)
@@ -185,9 +134,9 @@ def _run_local(
                 )
                 continue
 
-            flat_config = sample_random_config(
-                seed=seed + i, exclude_models=exclude_models
-            )
+            flat_config = sample_random_config(seed=seed + i)
+            if gpu:
+                flat_config["use_gpu"] = True
             db.insert_trial(i, flat_config)
 
             t0 = time.perf_counter()
@@ -305,6 +254,8 @@ def _run_local(
             if trial_score > best_score:
                 best_score = trial_score
                 best_config = flat_config
+
+        best_score, best_config = _best_from_db(db, objective)
 
     best_path = output_dir / "best_config.json"
     with open(best_path, "w", encoding="utf-8") as f:
@@ -458,6 +409,7 @@ def main(
     ] = "corr_sharpe",
     wandb_project: str | None = None,
     trial_timeout: int = 1800,
+    gpu: bool = False,
 ) -> None:
     """Run HPO search over preprocessing, models, and ensemble strategies.
 
@@ -466,6 +418,7 @@ def main(
     Pass --wandb-project <name> to log every trial to Weights & Biases.
     Pass --resume to continue an interrupted sweep (requires --local).
     Pass --trial-timeout N to cap each subprocess trial at N seconds (default: 1800).
+    Pass --gpu to enable CUDA for XGBoost and GPU task type for CatBoost.
     """
     set_global_seed(seed)
     if local:
@@ -480,6 +433,7 @@ def main(
             wandb_project=wandb_project,
             resume=resume,
             trial_timeout=trial_timeout,
+            gpu=gpu,
         )
     else:
         _run_ray(

--- a/scripts/hpo_pipeline.py
+++ b/scripts/hpo_pipeline.py
@@ -4,9 +4,9 @@ Supports two modes:
   --local   Random search (no extra dependencies).
   (default) Ray Tune distributed search (requires ``pip install 'alphapulse[hpo]'``).
 
-Each trial is scored via walk-forward backtesting (3 folds, n_purge=4) so
-that the objective reflects temporal out-of-sample performance rather than a
-fixed holdout split. The default objective is corr_sharpe from walk-forward.
+Each trial is scored via era holdout (fast mode, default) or walk-forward backtesting
+(3 folds with --no-fast) so the objective reflects temporal out-of-sample performance.
+Fast mode targets sub-30-minute trials on full data.
 
 Pass --wandb-project <name> to log every trial to Weights & Biases.
 Pass --resume to skip already-completed trials recorded in the trial database.
@@ -95,6 +95,7 @@ def _run_local(
     resume: bool = False,
     trial_timeout: int = 1800,
     gpu: bool = False,
+    fast: bool = True,
 ) -> None:
     """Local random-search HPO with subprocess isolation and SQLite trial DB."""
 
@@ -153,10 +154,20 @@ def _run_local(
                 )
                 continue
 
-            flat_config = sample_random_config(seed=seed + i)
+            flat_config = sample_random_config(seed=seed + i, fast=fast)
             if gpu:
                 flat_config["use_gpu"] = True
+            if fast:
+                flat_config["hpo_fast"] = True
             db.insert_trial(i, flat_config)
+
+            logger.info(
+                "Trial {}/{} starting (fast={}, models={})",
+                i + 1,
+                num_trials,
+                fast,
+                flat_config.get("model_1_type", "?"),
+            )
 
             t0 = time.perf_counter()
             result_queue: multiprocessing.Queue = _MP_CTX.Queue()
@@ -436,6 +447,7 @@ def main(
     wandb_project: str | None = None,
     trial_timeout: int = 1800,
     gpu: bool = False,
+    fast: bool = True,
 ) -> None:
     """Run HPO search over preprocessing, models, and ensemble strategies.
 
@@ -444,7 +456,10 @@ def main(
     Pass --wandb-project <name> to log every trial to Weights & Biases.
     Pass --resume to continue an interrupted sweep (requires --local).
     Pass --trial-timeout N to cap each subprocess trial at N seconds (default: 1800).
-    Pass --gpu to enable CUDA for XGBoost and GPU task type for CatBoost.
+    Pass --gpu to enable CUDA for XGBoost, LightGBM, and CatBoost.
+    Fast mode (default) uses era holdout and a tighter search space so trials
+    finish within ~30 minutes on full data.
+    Pass --no-fast for full walk-forward evaluation (slower).
     """
     set_global_seed(seed)
     if local:
@@ -460,6 +475,7 @@ def main(
             resume=resume,
             trial_timeout=trial_timeout,
             gpu=gpu,
+            fast=fast,
         )
     else:
         _run_ray(

--- a/scripts/live_inference.py
+++ b/scripts/live_inference.py
@@ -61,8 +61,8 @@ def main(
             benchmark = live_df[[benchmark_col]]
             predictions = predict_fn(live_df, benchmark)
         else:
-            # Fall back: call with live_df only
-            predictions = predict_fn(live_df, None)
+            # Fall back: call with empty benchmark DataFrame
+            predictions = predict_fn(live_df, pd.DataFrame())
     except Exception as exc:
         logger.error("Inference failed: {}", exc)
         raise SystemExit(1) from exc

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -14,6 +14,7 @@ def main(
     artifact_dir: Path | None = Path("artifacts/experiments"),
     seed: int = 42,
     wandb_project: str | None = None,
+    gpu: bool = False,
 ) -> None:
     """Load experiment file, train, evaluate; print metrics and config hash.
 
@@ -22,6 +23,7 @@ def main(
         artifact_dir: Directory to save artifacts. None to disable.
         seed: Random seed.
         wandb_project: WandB project name. When set, logs config and metrics.
+        gpu: Enable CUDA/GPU params for XGBoost and CatBoost models.
     """
     set_global_seed(seed)
     from alphapulse.experiments import run_experiment_from_path
@@ -32,10 +34,15 @@ def main(
         init_wandb_run(
             project=wandb_project,
             name=config.stem,
-            config={"config_path": str(config), "seed": seed},
+            config={"config_path": str(config), "seed": seed, "gpu": gpu},
         )
 
-    result = run_experiment_from_path(config, artifact_dir=artifact_dir)
+    result = run_experiment_from_path(
+        config,
+        artifact_dir=artifact_dir,
+        use_gpu=gpu,
+        log_wandb_diagnostics=bool(wandb_project),
+    )
 
     if wandb_project:
         from alphapulse.logging_.wandb_utils import (

--- a/src/alphapulse/autoresearch/loop.py
+++ b/src/alphapulse/autoresearch/loop.py
@@ -47,6 +47,7 @@ def _run_one_trial(
     era_train: pd.Series,
     feature_cols: list[str],
     seed: int,
+    meta_model: pd.Series | None = None,
 ) -> tuple[dict[str, float], float]:
     rng = np.random.default_rng(seed)
     np.random.seed(int(rng.integers(0, 2**31)))
@@ -72,7 +73,9 @@ def _run_one_trial(
         n_splits=WF_N_SPLITS,
         n_purge=WF_N_PURGE,
         min_train_eras=WF_MIN_TRAIN_ERAS,
-    ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)
+    ).evaluate_walk_forward(
+        X_train, y_train, era_train, train_fn, meta_model=meta_model
+    )
     return metrics, time.perf_counter() - t0
 
 
@@ -122,6 +125,7 @@ def run_autoresearch(
     agent_model: str = "claude-sonnet-4-6",
     resume: bool = False,
     wandb_project: str | None = None,
+    data_dir: Path | None = None,
 ) -> ResearchState:
     """Run the agent-driven research loop.
 
@@ -147,6 +151,14 @@ def run_autoresearch(
     output_dir.mkdir(parents=True, exist_ok=True)
     csv_path = output_dir / "trials_summary.csv"
     state_path = output_dir / "research_state.json"
+
+    meta_model: pd.Series | None = None
+    if data_dir is not None:
+        from ..experiments.data import load_meta_model_series
+
+        meta_model = load_meta_model_series(data_dir, X_train.index)
+        if meta_model is not None:
+            logger.info("Loaded meta_model.parquet for MMC/payout scoring")
 
     if wandb_project:
         from ..logging_.wandb_utils import finish_wandb_run, init_wandb_run
@@ -222,6 +234,7 @@ def run_autoresearch(
                 era_train=era_train,
                 feature_cols=feature_cols,
                 seed=seed + trial_num,
+                meta_model=meta_model,
             )
             sharpe = metrics.get("corr_sharpe", float("-inf"))
             error = None

--- a/src/alphapulse/autoresearch/mutations.py
+++ b/src/alphapulse/autoresearch/mutations.py
@@ -10,6 +10,9 @@ VALID_MODELS = [
     "LightGBM",
     "Packboost",
     "CatBoost",
+    "Ridge",
+    "RandomForest",
+    "ExtraTrees",
     "TabPFN",
     "TabPFN3",
     "TabPFN3Reasoning",
@@ -30,6 +33,25 @@ VALID_ENSEMBLE_METHODS = ["single", "weighted", "stacking"]
 MAX_MODELS = 4
 
 
+def _model_param_dict(model_entry: dict[str, Any]) -> dict[str, Any]:
+    params = model_entry.get("params") or {}
+    inner = params.get("params")
+    if isinstance(inner, dict):
+        return inner
+    return params
+
+
+def _set_model_param_dict(model_entry: dict[str, Any], updates: dict[str, Any]) -> None:
+    params = dict(model_entry.get("params") or {})
+    if "params" in params and isinstance(params["params"], dict):
+        inner = dict(params["params"])
+        inner.update(updates)
+        params["params"] = inner
+    else:
+        params.update(updates)
+    model_entry["params"] = params
+
+
 def tune_model_params(
     config: dict[str, Any], model_index: int, param_updates: dict[str, Any]
 ) -> dict[str, Any]:
@@ -39,9 +61,9 @@ def tune_model_params(
         raise ValueError(
             f"model_index {model_index} out of range (have {len(models)} models)"
         )
-    existing = dict(models[model_index].get("params") or {})
+    existing = dict(_model_param_dict(models[model_index]))
     existing.update(param_updates)
-    models[model_index]["params"] = existing
+    _set_model_param_dict(models[model_index], existing)
     config["models"] = models
     return config
 

--- a/src/alphapulse/evaluation/backtester.py
+++ b/src/alphapulse/evaluation/backtester.py
@@ -13,6 +13,19 @@ class PredictorProtocol(Protocol):
     def predict(self, X: pd.DataFrame) -> np.ndarray: ...
 
 
+def predict_with_optional_eras(
+    predictor: PredictorProtocol,
+    X: pd.DataFrame,
+    era: pd.Series,
+) -> np.ndarray:
+    if float(getattr(predictor, "neutralize_proportion", 0.0)) > 0.0:
+        return np.asarray(
+            predictor.predict(X, eras=era),  # type: ignore[call-arg]
+            dtype=np.float64,
+        )
+    return np.asarray(predictor.predict(X), dtype=np.float64)
+
+
 class Backtester:
     """Evaluate a fitted predictor on an (X, y, era) validation split.
 
@@ -68,7 +81,7 @@ class Backtester:
             ``mmc_sharpe``, ``payout_score``, ``fnc_sharpe``.
         """
         X_use = X[self.feature_columns] if self.feature_columns is not None else X
-        preds = self.predictor.predict(X_use)
+        preds = predict_with_optional_eras(self.predictor, X_use, era)
 
         if self.neutralizer is not None:
             preds = self.neutralizer.neutralize(preds, X_use, era)

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -15,6 +15,11 @@ WF_N_SPLITS = 3
 WF_N_PURGE = 4
 WF_MIN_TRAIN_ERAS = 20
 
+HPO_FAST_HOLDOUT_ERAS = 52
+HPO_FAST_WF_N_SPLITS = 2
+HPO_FAST_MAX_TRAIN_ERAS = 120
+HPO_FAST_N_SUBS_CAP = 5
+
 _NAN_METRICS: dict[str, float] = {
     "mean_per_era_correlation": float("nan"),
     "std_per_era_correlation": float("nan"),
@@ -81,6 +86,7 @@ class EraSplitEvaluator:
         n_purge: int = 4,
         n_embargo: int = 0,
         n_splits: int | None = None,
+        max_train_eras: int | None = None,
         neutralizer: "FeatureNeutralizer | None" = None,
     ) -> None:
         if n_purge < 0:
@@ -94,6 +100,7 @@ class EraSplitEvaluator:
         self.n_purge = n_purge
         self.n_embargo = n_embargo
         self.n_splits = n_splits
+        self.max_train_eras = max_train_eras
         self.neutralizer = neutralizer
 
     def evaluate_walk_forward(
@@ -212,6 +219,7 @@ class EraSplitEvaluator:
             n_purge=self.n_purge,
             n_embargo=self.n_embargo,
             min_train_eras=self.min_train_eras,
+            max_train_eras=self.max_train_eras,
         )
         for train_eras, test_eras in cv.split_eras(era_series):
             train_mask = era_series.isin(set(train_eras))
@@ -238,6 +246,10 @@ class EraSplitEvaluator:
 
 
 __all__ = [
+    "HPO_FAST_HOLDOUT_ERAS",
+    "HPO_FAST_MAX_TRAIN_ERAS",
+    "HPO_FAST_N_SUBS_CAP",
+    "HPO_FAST_WF_N_SPLITS",
     "WF_MIN_TRAIN_ERAS",
     "WF_N_PURGE",
     "WF_N_SPLITS",

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -107,6 +107,10 @@ class EraSplitEvaluator:
         train_fn: Callable[[pd.DataFrame, pd.Series], PredictorProtocol],
         eras_order: list[Any] | None = None,
         meta_model: pd.Series | None = None,
+        last_fold_callback: Callable[
+            [PredictorProtocol, pd.DataFrame, pd.Series, pd.Series], None
+        ]
+        | None = None,
     ) -> dict[str, float]:
         X_use = X[self.feature_columns] if self.feature_columns is not None else X
         df = pd.concat(
@@ -131,6 +135,7 @@ class EraSplitEvaluator:
                 all_era,
                 meta_model=meta_model,
                 all_meta=all_meta if meta_model is not None else None,
+                last_fold_callback=last_fold_callback,
             )
         else:
             self._collect_expanding(
@@ -143,6 +148,7 @@ class EraSplitEvaluator:
                 all_era,
                 meta_model=meta_model,
                 all_meta=all_meta if meta_model is not None else None,
+                last_fold_callback=last_fold_callback,
             )
 
         if not all_y_true:
@@ -166,6 +172,10 @@ class EraSplitEvaluator:
         *,
         meta_model: pd.Series | None = None,
         all_meta: list[float] | None = None,
+        last_fold_callback: Callable[
+            [PredictorProtocol, pd.DataFrame, pd.Series, pd.Series], None
+        ]
+        | None = None,
     ) -> None:
         step = self.n_embargo + 1
         first_test = self.min_train_eras + self.n_purge
@@ -196,6 +206,8 @@ class EraSplitEvaluator:
             all_era.extend([test_era] * len(y_te))
             if meta_model is not None and all_meta is not None:
                 all_meta.extend(meta_model.loc[y_te.index].tolist())
+            if last_fold_callback is not None:
+                last_fold_callback(predictor, X_te, y_te, era_labels)
 
     def _collect_purged_cv(
         self,
@@ -208,6 +220,10 @@ class EraSplitEvaluator:
         *,
         meta_model: pd.Series | None = None,
         all_meta: list[float] | None = None,
+        last_fold_callback: Callable[
+            [PredictorProtocol, pd.DataFrame, pd.Series, pd.Series], None
+        ]
+        | None = None,
     ) -> None:
         era_series = df["era"]
         cv = PurgedEraCV(
@@ -239,6 +255,8 @@ class EraSplitEvaluator:
             all_era.extend(era_series.loc[test_mask].tolist())
             if meta_model is not None and all_meta is not None:
                 all_meta.extend(meta_model.loc[y_te.index].tolist())
+            if last_fold_callback is not None:
+                last_fold_callback(predictor, X_te, y_te, fold_eras)
 
 
 __all__ = [

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -1,11 +1,11 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
 
 from ..validation.purged_cv import PurgedEraCV
-from .backtester import Backtester
+from .backtester import Backtester, PredictorProtocol, predict_with_optional_eras
 from .metrics import calculate_metrics, rank_normalize_per_era
 
 if TYPE_CHECKING:
@@ -28,10 +28,6 @@ _NAN_METRICS: dict[str, float] = {
     "pct_positive_eras": float("nan"),
     "n_valid_eras": float("nan"),
 }
-
-
-class PredictorProtocol(Protocol):
-    def predict(self, X: pd.DataFrame) -> np.ndarray: ...
 
 
 def evaluate_holdout_last_n_eras(
@@ -191,9 +187,9 @@ class EraSplitEvaluator:
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
             y_te = cast(pd.Series, df.loc[test_mask, "y"])
             predictor = train_fn(X_tr, y_tr)
-            preds = predictor.predict(X_te)
+            era_labels = pd.Series([test_era] * len(y_te), index=y_te.index)
+            preds = predict_with_optional_eras(predictor, X_te, era_labels)
             if self.neutralizer is not None:
-                era_labels = pd.Series([test_era] * len(y_te), index=y_te.index)
                 preds = self.neutralizer.neutralize(preds, X_te, era_labels)
             all_y_true.extend(y_te.tolist())
             all_y_pred.extend(np.asarray(preds).ravel().tolist())
@@ -234,9 +230,9 @@ class EraSplitEvaluator:
             X_te = cast(pd.DataFrame, df.loc[test_mask, X_use.columns])
             y_te = cast(pd.Series, df.loc[test_mask, "y"])
             predictor = train_fn(X_tr, y_tr)
-            preds = predictor.predict(X_te)
+            fold_eras = era_series.loc[test_mask]
+            preds = predict_with_optional_eras(predictor, X_te, fold_eras)
             if self.neutralizer is not None:
-                fold_eras = era_series.loc[test_mask]
                 preds = self.neutralizer.neutralize(preds, X_te, fold_eras)
             all_y_true.extend(y_te.tolist())
             all_y_pred.extend(np.asarray(preds).ravel().tolist())

--- a/src/alphapulse/evaluation/era_split.py
+++ b/src/alphapulse/evaluation/era_split.py
@@ -103,6 +103,7 @@ class EraSplitEvaluator:
         era: pd.Series,
         train_fn: Callable[[pd.DataFrame, pd.Series], PredictorProtocol],
         eras_order: list[Any] | None = None,
+        meta_model: pd.Series | None = None,
     ) -> dict[str, float]:
         X_use = X[self.feature_columns] if self.feature_columns is not None else X
         df = pd.concat(
@@ -115,14 +116,30 @@ class EraSplitEvaluator:
         all_y_true: list[float] = []
         all_y_pred: list[float] = []
         all_era: list[Any] = []
+        all_meta: list[float] = []
 
         if self.n_splits is not None:
             self._collect_purged_cv(
-                df, X_use, train_fn, all_y_true, all_y_pred, all_era
+                df,
+                X_use,
+                train_fn,
+                all_y_true,
+                all_y_pred,
+                all_era,
+                meta_model=meta_model,
+                all_meta=all_meta if meta_model is not None else None,
             )
         else:
             self._collect_expanding(
-                df, X_use, eras_order, train_fn, all_y_true, all_y_pred, all_era
+                df,
+                X_use,
+                eras_order,
+                train_fn,
+                all_y_true,
+                all_y_pred,
+                all_era,
+                meta_model=meta_model,
+                all_meta=all_meta if meta_model is not None else None,
             )
 
         if not all_y_true:
@@ -131,7 +148,8 @@ class EraSplitEvaluator:
         y_s = pd.Series(all_y_true)
         era_s = pd.Series(all_era)
         pred_a = rank_normalize_per_era(np.asarray(all_y_pred, dtype=np.float64), era_s)
-        return calculate_metrics(y_s, pred_a, era_s)
+        meta_arr = np.asarray(all_meta, dtype=np.float64) if all_meta else None
+        return calculate_metrics(y_s, pred_a, era_s, meta_model_preds=meta_arr)
 
     def _collect_expanding(
         self,
@@ -142,6 +160,9 @@ class EraSplitEvaluator:
         all_y_true: list[float],
         all_y_pred: list[float],
         all_era: list[Any],
+        *,
+        meta_model: pd.Series | None = None,
+        all_meta: list[float] | None = None,
     ) -> None:
         step = self.n_embargo + 1
         first_test = self.min_train_eras + self.n_purge
@@ -170,6 +191,8 @@ class EraSplitEvaluator:
             all_y_true.extend(y_te.tolist())
             all_y_pred.extend(np.asarray(preds).ravel().tolist())
             all_era.extend([test_era] * len(y_te))
+            if meta_model is not None and all_meta is not None:
+                all_meta.extend(meta_model.loc[y_te.index].tolist())
 
     def _collect_purged_cv(
         self,
@@ -179,6 +202,9 @@ class EraSplitEvaluator:
         all_y_true: list[float],
         all_y_pred: list[float],
         all_era: list[Any],
+        *,
+        meta_model: pd.Series | None = None,
+        all_meta: list[float] | None = None,
     ) -> None:
         era_series = df["era"]
         cv = PurgedEraCV(
@@ -207,6 +233,8 @@ class EraSplitEvaluator:
             all_y_true.extend(y_te.tolist())
             all_y_pred.extend(np.asarray(preds).ravel().tolist())
             all_era.extend(era_series.loc[test_mask].tolist())
+            if meta_model is not None and all_meta is not None:
+                all_meta.extend(meta_model.loc[y_te.index].tolist())
 
 
 __all__ = [

--- a/src/alphapulse/evaluation/shap_report.py
+++ b/src/alphapulse/evaluation/shap_report.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xgboost as xgb
+
+from ..models.base import _numeric
+from ..models.era_ensemble_model import EraEnsembleModel
+from ..models.xgboost_model import XGBoostModel
+from ..pipeline.multihead import MultiHeadPipeline
+from ..pipeline.pipeline import Pipeline
+
+SHAP_SAMPLE_ROWS = 2000
+
+
+def _wandb_active() -> bool:
+    try:
+        import wandb
+
+        return wandb.run is not None
+    except ImportError:
+        return False
+
+
+def _xgb_contribs(model: XGBoostModel, X: pd.DataFrame) -> tuple[np.ndarray, list[str]]:
+    feat = _numeric(X)
+    dmat = xgb.DMatrix(feat)
+    contribs = model.model.predict(dmat, pred_contribs=True)
+    cols = list(feat.columns)
+    return np.asarray(contribs, dtype=np.float64), cols
+
+
+def _collect_xgboost_models(
+    pipeline: Pipeline | MultiHeadPipeline,
+) -> list[tuple[str, XGBoostModel]]:
+    models: list[tuple[str, XGBoostModel]] = []
+    if isinstance(pipeline, MultiHeadPipeline):
+        for head in pipeline.heads:
+            m = head.model
+            if isinstance(m, XGBoostModel):
+                models.append((m.name, m))
+            elif isinstance(m, EraEnsembleModel):
+                for sub in m._sub_models:
+                    if isinstance(sub, XGBoostModel):
+                        models.append((sub.name, sub))
+        return models
+
+    for model in pipeline.models:
+        if isinstance(model, XGBoostModel):
+            models.append((model.name, model))
+        elif isinstance(model, EraEnsembleModel):
+            for sub in model._sub_models:
+                if isinstance(sub, XGBoostModel):
+                    models.append((sub.name, sub))
+    return models
+
+
+def compute_xgboost_feature_importance(
+    pipeline: Pipeline | MultiHeadPipeline,
+    X: pd.DataFrame,
+    *,
+    top_n: int = 20,
+    max_rows: int = SHAP_SAMPLE_ROWS,
+) -> dict[str, float]:
+    xgb_models = _collect_xgboost_models(pipeline)
+    if not xgb_models:
+        return {}
+
+    sample = X
+    if len(X) > max_rows:
+        sample = X.sample(n=max_rows, random_state=0)
+
+    aggregated: dict[str, list[float]] = {}
+    for _, model in xgb_models:
+        contribs, cols = _xgb_contribs(model, sample)
+        mean_abs = np.mean(np.abs(contribs[:, :-1]), axis=0)
+        for col, value in zip(cols, mean_abs, strict=False):
+            aggregated.setdefault(col, []).append(float(value))
+
+    averaged = {col: float(np.mean(vals)) for col, vals in aggregated.items()}
+    ranked = sorted(averaged.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+    return dict(ranked)
+
+
+def log_xgboost_shap_importance(
+    pipeline: Pipeline | MultiHeadPipeline,
+    X: pd.DataFrame,
+    *,
+    top_n: int = 20,
+) -> None:
+    if not _wandb_active():
+        return
+
+    import wandb
+
+    importance = compute_xgboost_feature_importance(pipeline, X, top_n=top_n)
+    if not importance:
+        return
+
+    table = wandb.Table(columns=["feature", "mean_abs_contribution"])
+    for feature, score in importance.items():
+        table.add_data(feature, score)
+    wandb.log(
+        {
+            "diagnostics/shap_top_features": table,
+            "diagnostics/shap_bar": wandb.plot.bar(
+                table,
+                "feature",
+                "mean_abs_contribution",
+                title="Top feature contributions (XGBoost pred_contribs)",
+            ),
+        }
+    )

--- a/src/alphapulse/evaluation/wandb_diagnostics.py
+++ b/src/alphapulse/evaluation/wandb_diagnostics.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from ..evaluation.metrics import per_era_correlation, rank_normalize
+from ..pipeline.multihead import MultiHeadPipeline
+from ..pipeline.pipeline import Pipeline
+from ..pipeline.row_utils import protected_metadata_frame
+
+MAX_SCATTER_POINTS = 5000
+MAX_HEXBIN_POINTS = 10_000
+FEATURE_EXPOSURE_TOP_N = 15
+MAX_FNC_FEATURES = 200
+
+
+def _wandb_active() -> bool:
+    try:
+        import wandb
+
+        return wandb.run is not None
+    except ImportError:
+        return False
+
+
+def _collect_model_predictions(
+    pipeline: Pipeline | MultiHeadPipeline,
+    X_val: pd.DataFrame,
+    feature_cols: list[str],
+) -> dict[str, np.ndarray]:
+    if isinstance(pipeline, MultiHeadPipeline):
+        preds = pipeline.predict(X_val[feature_cols] if feature_cols else X_val)
+        return {"ensemble": preds}
+
+    X_feat = X_val[feature_cols] if feature_cols else X_val
+    era_meta = protected_metadata_frame(X_feat)
+    X_t = pipeline._preprocess(X_feat, era_meta)
+    X_numeric = X_t.select_dtypes(include=[np.number])
+
+    if len(pipeline.models) == 1:
+        return {pipeline.models[0].name: pipeline.models[0].predict(X_numeric)}
+    return {m.name: m.predict(X_numeric) for m in pipeline.models}
+
+
+def _feature_exposure_summary(
+    preds: np.ndarray,
+    features: pd.DataFrame,
+    eras: pd.Series,
+    *,
+    top_n: int = FEATURE_EXPOSURE_TOP_N,
+) -> dict[str, Any]:
+    e_arr = np.asarray(eras.to_numpy())
+    unique_eras = sorted(pd.unique(e_arr), key=str)
+    per_feature: dict[str, list[float]] = {c: [] for c in features.columns}
+
+    for era in unique_eras:
+        mask = e_arr == era
+        if mask.sum() < 3:
+            continue
+        p = preds[mask]
+        for col in features.columns:
+            f = features[col].to_numpy()[mask]
+            if np.std(p) == 0 or np.std(f) == 0:
+                continue
+            corr = float(np.corrcoef(p, f)[0, 1])
+            if np.isfinite(corr):
+                per_feature[col].append(abs(corr))
+
+    mean_abs = {col: float(np.mean(vals)) for col, vals in per_feature.items() if vals}
+    if not mean_abs:
+        return {
+            "max_mean_abs_corr": float("nan"),
+            "mean_abs_corr": float("nan"),
+            "top": [],
+        }
+
+    ranked = sorted(mean_abs.items(), key=lambda kv: kv[1], reverse=True)
+    top = [{"feature": k, "mean_abs_corr": v} for k, v in ranked[:top_n]]
+    all_vals = list(mean_abs.values())
+    return {
+        "max_mean_abs_corr": max(all_vals),
+        "mean_abs_corr": float(np.mean(all_vals)),
+        "top": top,
+    }
+
+
+def log_experiment_diagnostics(
+    *,
+    pipeline: Pipeline | MultiHeadPipeline,
+    X_val: pd.DataFrame,
+    y_val: pd.Series,
+    era_val: pd.Series,
+    feature_cols: list[str],
+    metrics: dict[str, float],
+    meta_model_preds: np.ndarray | None = None,
+    log_shap: bool = True,
+    compute_fnc: bool | None = None,
+) -> None:
+    if not _wandb_active():
+        return
+
+    import wandb
+
+    X_use = X_val[feature_cols] if feature_cols else X_val
+    neutralize = getattr(pipeline, "neutralize_proportion", 0)
+    eras_for_predict = era_val if neutralize > 0 else None
+    if isinstance(pipeline, Pipeline):
+        preds = pipeline.predict(X_use, eras=eras_for_predict)
+    else:
+        preds = pipeline.predict(X_val[feature_cols] if feature_cols else X_val)
+
+    _log_per_era_correlation(y_val, preds, era_val)
+    _log_prediction_diagnostics(y_val, preds)
+    _log_feature_exposure(preds, X_use, era_val)
+
+    if isinstance(pipeline, Pipeline) and len(pipeline.models) > 1:
+        _log_ensemble_diagnostics(pipeline, X_val, feature_cols, y_val, era_val)
+
+    if meta_model_preds is not None:
+        wandb.log(
+            {
+                "diagnostics/mmc_sharpe": metrics.get("mmc_sharpe"),
+                "diagnostics/payout_score": metrics.get("payout_score"),
+            }
+        )
+
+    use_fnc = compute_fnc
+    if use_fnc is None:
+        use_fnc = len(feature_cols) <= MAX_FNC_FEATURES
+    if use_fnc and "fnc_sharpe" in metrics:
+        wandb.log({"diagnostics/fnc_sharpe": metrics["fnc_sharpe"]})
+
+    if log_shap:
+        from ..evaluation.shap_report import log_xgboost_shap_importance
+
+        log_xgboost_shap_importance(pipeline, X_use, top_n=20)
+
+
+def _log_per_era_correlation(
+    y_val: pd.Series, preds: np.ndarray, era_val: pd.Series
+) -> None:
+    import wandb
+
+    per_era = per_era_correlation(y_val, preds, era_val, method="spearman").dropna()
+    if per_era.empty:
+        return
+
+    cumulative = per_era.cumsum()
+    table = wandb.Table(columns=["era", "correlation", "cumulative_correlation"])
+    for era, corr in per_era.items():
+        table.add_data(str(era), float(corr), float(cumulative.loc[era]))
+
+    wandb.log(
+        {
+            "diagnostics/per_era_correlation_table": table,
+            "diagnostics/per_era_correlation": wandb.plot.line(
+                table, "era", "correlation", title="Per-era correlation"
+            ),
+            "diagnostics/cumulative_correlation": wandb.plot.line(
+                table,
+                "era",
+                "cumulative_correlation",
+                title="Cumulative per-era correlation",
+            ),
+        }
+    )
+
+
+def _log_prediction_diagnostics(y_val: pd.Series, preds: np.ndarray) -> None:
+    import wandb
+
+    ranked = rank_normalize(preds)
+    hist_table = wandb.Table(columns=["rank_normalized_prediction"])
+    for value in ranked[np.isfinite(ranked)]:
+        hist_table.add_data(float(value))
+    wandb.log(
+        {
+            "diagnostics/prediction_histogram": wandb.plot.histogram(
+                hist_table,
+                "rank_normalized_prediction",
+                title="Rank-normalized predictions",
+            )
+        }
+    )
+
+    n = min(len(y_val), MAX_SCATTER_POINTS)
+    if n < len(y_val):
+        idx = np.random.default_rng(0).choice(len(y_val), size=n, replace=False)
+        y_sample = y_val.iloc[idx]
+        p_sample = preds[idx]
+    else:
+        y_sample = y_val
+        p_sample = preds
+
+    scatter = wandb.Table(columns=["target", "prediction"])
+    for yt, pp in zip(y_sample, p_sample, strict=False):
+        if np.isfinite(yt) and np.isfinite(pp):
+            scatter.add_data(float(yt), float(pp))
+    wandb.log(
+        {
+            "diagnostics/pred_vs_target_scatter": wandb.plot.scatter(
+                scatter,
+                "target",
+                "prediction",
+                title="Predictions vs target (sampled)",
+            )
+        }
+    )
+
+    residuals = y_val.to_numpy(dtype=np.float64) - preds
+    finite = residuals[np.isfinite(residuals)]
+    if len(finite):
+        wandb.log(
+            {
+                "diagnostics/residual_mean": float(np.mean(finite)),
+                "diagnostics/residual_std": float(np.std(finite, ddof=0)),
+                "diagnostics/residual_mae": float(np.mean(np.abs(finite))),
+            }
+        )
+
+
+def _log_feature_exposure(
+    preds: np.ndarray, features: pd.DataFrame, eras: pd.Series
+) -> None:
+    import wandb
+
+    summary = _feature_exposure_summary(preds, features, eras)
+    wandb.log(
+        {
+            "diagnostics/feature_exposure_max": summary["max_mean_abs_corr"],
+            "diagnostics/feature_exposure_mean": summary["mean_abs_corr"],
+        }
+    )
+    if summary["top"]:
+        table = wandb.Table(columns=["feature", "mean_abs_corr"])
+        for row in summary["top"]:
+            table.add_data(row["feature"], row["mean_abs_corr"])
+        wandb.log({"diagnostics/feature_exposure_top": table})
+
+
+def _log_ensemble_diagnostics(
+    pipeline: Pipeline | MultiHeadPipeline,
+    X_val: pd.DataFrame,
+    feature_cols: list[str],
+    y_val: pd.Series,
+    era_val: pd.Series,
+) -> None:
+    import wandb
+
+    from ..evaluation.ensemble_diagnostics import compute_ensemble_diagnostics
+
+    oof = _collect_model_predictions(pipeline, X_val, feature_cols)
+    weights = None
+    if isinstance(pipeline, Pipeline) and pipeline.ensemble_method == "weighted":
+        w = pipeline._ensemble.params.get("weights")
+        if w is not None:
+            weights = np.asarray(w, dtype=np.float64)
+
+    diag = compute_ensemble_diagnostics(
+        oof,
+        y_val.to_numpy(dtype=np.float64),
+        era_val,
+        weights=weights,
+    )
+    wandb.log(
+        {
+            "diagnostics/effective_model_count": diag["effective_model_count"],
+            "diagnostics/mean_pairwise_correlation": diag["mean_pairwise_correlation"],
+        }
+    )
+    names = diag["model_names"]
+    corr = diag["correlation_matrix"]
+    table = wandb.Table(columns=["model_a", "model_b", "correlation"])
+    for i, a in enumerate(names):
+        for j, b in enumerate(names):
+            if j >= i:
+                table.add_data(a, b, corr[a][b])
+    wandb.log({"diagnostics/ensemble_correlation_matrix": table})

--- a/src/alphapulse/experiments/data.py
+++ b/src/alphapulse/experiments/data.py
@@ -3,6 +3,43 @@ from pathlib import Path
 
 import pandas as pd
 
+META_MODEL_COLUMN_CANDIDATES = ("meta_model", "prediction", "meta")
+
+
+def load_meta_model_series(
+    data_dir: Path,
+    index: pd.Index,
+    *,
+    meta_model_path: str | None = None,
+) -> pd.Series | None:
+    path = (
+        Path(meta_model_path)
+        if meta_model_path
+        else Path(data_dir) / "meta_model.parquet"
+    )
+    if not path.exists():
+        return None
+
+    meta_df = pd.read_parquet(path)
+    value_col = next(
+        (c for c in META_MODEL_COLUMN_CANDIDATES if c in meta_df.columns),
+        None,
+    )
+    if value_col is None:
+        numeric_cols = meta_df.select_dtypes(include=["number"]).columns
+        if len(numeric_cols) == 0:
+            return None
+        value_col = str(numeric_cols[0])
+
+    if "id" in meta_df.columns:
+        aligned = meta_df.set_index("id")[value_col]
+        return aligned.reindex(index)
+    if meta_df.index.equals(index):
+        return meta_df[value_col]
+    if len(meta_df) == len(index):
+        return pd.Series(meta_df[value_col].to_numpy(), index=index)
+    return meta_df[value_col].reindex(index)
+
 
 def load_feature_names(
     data_dir: Path,
@@ -77,8 +114,8 @@ def load_train_val_frames(
     need_era: bool,
     benchmark_columns: list[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series, pd.Series, list[str]]:
-    if train_subsample <= 0.0:
-        raise ValueError(f"train_subsample must be > 0, got {train_subsample}")
+    if not 0.0 < train_subsample <= 1.0:
+        raise ValueError(f"train_subsample must be in (0, 1], got {train_subsample}")
 
     train_path = data_dir / "train.parquet"
     val_path = data_dir / "validation.parquet"
@@ -110,6 +147,8 @@ def load_train_val_frames(
         raise ValueError("No feature columns resolved after excluding metadata.")
     read_cols = cols + (["era"] if need_era else [])
     train_df = train_df.sample(frac=train_subsample, random_state=seed)
+    if "era" in train_df.columns:
+        train_df = train_df.sort_values("era", kind="mergesort")
     return (
         train_df[read_cols],
         train_df[target_col],
@@ -131,6 +170,9 @@ def load_train_only_frame(
     benchmark_columns: list[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, list[str]]:
     """Load only train.parquet (no validation) with column pruning to reduce RAM."""
+    if not 0.0 < train_subsample <= 1.0:
+        raise ValueError(f"train_subsample must be in (0, 1], got {train_subsample}")
+
     train_path = data_dir / "train.parquet"
     if not train_path.exists():
         raise FileNotFoundError(f"Expected {train_path}")
@@ -159,6 +201,8 @@ def load_train_only_frame(
     read_cols = cols + (["era"] if need_era else [])
 
     train_df = train_df.sample(frac=train_subsample, random_state=seed)
+    if "era" in train_df.columns:
+        train_df = train_df.sort_values("era", kind="mergesort")
     return train_df[read_cols], train_df[target_col], cols
 
 
@@ -171,6 +215,9 @@ def load_train_frame_with_era(
     need_era: bool,
     benchmark_columns: list[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.Series, list[str]]:
+    if not 0.0 < train_subsample <= 1.0:
+        raise ValueError(f"train_subsample must be in (0, 1], got {train_subsample}")
+
     train_path = data_dir / "train.parquet"
     if not train_path.exists():
         raise FileNotFoundError(f"Expected {train_path}")
@@ -194,4 +241,6 @@ def load_train_frame_with_era(
         raise ValueError("No feature columns resolved after excluding metadata.")
     x_cols = cols + (["era"] if need_era else [])
     train_df = train_df.sample(frac=train_subsample, random_state=seed)
+    if "era" in train_df.columns:
+        train_df = train_df.sort_values("era", kind="mergesort")
     return train_df[x_cols], train_df[target_col], train_df["era"], cols

--- a/src/alphapulse/experiments/runner.py
+++ b/src/alphapulse/experiments/runner.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import yaml
 from loguru import logger
 
@@ -13,7 +14,11 @@ from ..evaluation.era_split import EraSplitEvaluator, evaluate_holdout_last_n_er
 from ..hpo.builder import TREE_MODEL_NAMES, build_pipeline_or_multi
 from ..pipeline.multihead import MultiHeadPipeline
 from ..pipeline.pipeline import Pipeline
-from .data import load_train_frame_with_era, load_train_val_frames
+from .data import (
+    load_meta_model_series,
+    load_train_frame_with_era,
+    load_train_val_frames,
+)
 from .hashing import config_hash
 from .schema import ExperimentV1
 from .split import internal_val_split
@@ -54,7 +59,13 @@ def _need_era_column(exp: ExperimentV1) -> bool:
     return False
 
 
-def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> RunResult:
+def run_experiment(
+    exp: ExperimentV1,
+    *,
+    artifact_dir: Path | None = None,
+    use_gpu: bool = False,
+    log_wandb_diagnostics: bool | None = None,
+) -> RunResult:
     """Execute a full experiment: load data, build pipeline, train, and backtest.
 
     Args:
@@ -68,6 +79,10 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
     """
     t0 = time.perf_counter()
     pipeline_cfg = exp.to_pipeline_config()
+    if use_gpu:
+        from ..hpo.search_space import apply_gpu_pipeline_config
+
+        pipeline_cfg = apply_gpu_pipeline_config(pipeline_cfg)
     ch = config_hash(
         {
             "version": exp.version,
@@ -133,8 +148,47 @@ def run_experiment(exp: ExperimentV1, *, artifact_dir: Path | None = None) -> Ru
         )
 
     gc.collect()
+    meta_path = exp.evaluation.meta_model_path
+    meta_model_preds = None
+    meta_series = load_meta_model_series(
+        data_dir, X_val.index, meta_model_path=meta_path
+    )
+    if meta_series is not None:
+        meta_model_preds = meta_series.reindex(X_val.index).to_numpy(dtype=np.float64)
+
+    compute_fnc = len(feature_cols) <= 200
     backtester = Backtester(pipeline, feature_columns=feature_cols)
-    metrics = backtester.evaluate(X_val, y_val, era_val)
+    metrics = backtester.evaluate(
+        X_val,
+        y_val,
+        era_val,
+        meta_model_preds=meta_model_preds,
+        compute_fnc=compute_fnc,
+        corr_weight=exp.evaluation.corr_weight,
+        mmc_weight=exp.evaluation.mmc_weight,
+    )
+
+    should_log_diag = log_wandb_diagnostics
+    if should_log_diag is None:
+        try:
+            import wandb
+
+            should_log_diag = wandb.run is not None
+        except ImportError:
+            should_log_diag = False
+    if should_log_diag:
+        from ..evaluation.wandb_diagnostics import log_experiment_diagnostics
+
+        log_experiment_diagnostics(
+            pipeline=pipeline,
+            X_val=X_val,
+            y_val=y_val,
+            era_val=era_val,
+            feature_cols=feature_cols,
+            metrics=metrics,
+            meta_model_preds=meta_model_preds,
+            compute_fnc=compute_fnc,
+        )
 
     ev = exp.evaluation
     if ev.era_holdout_last_n is not None:

--- a/src/alphapulse/experiments/schema.py
+++ b/src/alphapulse/experiments/schema.py
@@ -84,7 +84,7 @@ class NeutralizationConfig(BaseModel):
     rank-normalized back to [0, 1] before scoring or submission.
     """
 
-    proportion: float = Field(0.35, ge=0.0, le=1.0)
+    proportion: float = Field(0.0, ge=0.0, le=1.0)
     features: list[str] | None = None
 
 

--- a/src/alphapulse/experiments/schema.py
+++ b/src/alphapulse/experiments/schema.py
@@ -84,7 +84,7 @@ class NeutralizationConfig(BaseModel):
     rank-normalized back to [0, 1] before scoring or submission.
     """
 
-    proportion: float = Field(0.0, ge=0.0, le=1.0)
+    proportion: float = Field(0.35, ge=0.0, le=1.0)
     features: list[str] | None = None
 
 

--- a/src/alphapulse/experiments/split.py
+++ b/src/alphapulse/experiments/split.py
@@ -17,6 +17,12 @@ def internal_val_split(
     *,
     force_internal: bool = False,
 ) -> tuple[Any, Any, Any, Any]:
+    if not y_train.index.equals(X_train.index):
+        X_train = X_train.reset_index(drop=True)
+        y_train = y_train.reset_index(drop=True)
+        if era_train is not None:
+            era_train = era_train.reset_index(drop=True)
+
     use_split = force_internal or len(X_train) > INTERNAL_VAL_THRESHOLD
     if not use_split:
         return X_train, y_train, None, None

--- a/src/alphapulse/experiments/split.py
+++ b/src/alphapulse/experiments/split.py
@@ -22,7 +22,7 @@ def internal_val_split(
         return X_train, y_train, None, None
 
     if era_train is not None:
-        unique_eras = era_train.unique()
+        unique_eras = sorted(era_train.unique(), key=str)
         if len(unique_eras) >= MIN_ERAS_FOR_INTERNAL_SPLIT:
             n_val_eras = max(1, int(len(unique_eras) * INTERNAL_VAL_ERA_FRACTION))
             val_eras = set(unique_eras[-n_val_eras:])
@@ -33,13 +33,17 @@ def internal_val_split(
                 X_train[mask],
                 y_train[mask],
             )
+        return X_train, y_train, None, None
 
     n_val = max(1, int(len(X_train) * INTERNAL_VAL_FRACTION))
     if n_val >= len(X_train):
         n_val = max(1, len(X_train) // 10)
+    sorted_idx = X_train.sort_index().index
+    X_sorted = X_train.loc[sorted_idx]
+    y_sorted = y_train.loc[sorted_idx]
     return (
-        X_train.iloc[:-n_val],
-        y_train.iloc[:-n_val],
-        X_train.tail(n_val),
-        y_train.tail(n_val),
+        X_sorted.iloc[:-n_val],
+        y_sorted.iloc[:-n_val],
+        X_sorted.iloc[-n_val:],
+        y_sorted.iloc[-n_val:],
     )

--- a/src/alphapulse/hpo/builder.py
+++ b/src/alphapulse/hpo/builder.py
@@ -8,6 +8,7 @@ from ..pipeline.pipeline import Pipeline
 from ..preprocessors.base import BasePreprocessor
 from ..preprocessors.grouped import GroupedPreprocessor
 from .registry import MODEL_REGISTRY, PREPROCESSOR_REGISTRY
+from .search_space import strip_catboost_gpu_incompatible_params
 
 TREE_MODEL_NAMES = frozenset(
     {"XGBoost", "LightGBM", "CatBoost", "RandomForest", "ExtraTrees"}
@@ -84,6 +85,8 @@ def instantiate_model(
         raise ValueError(f"Unknown model type: {type_name}")
     cls, defaults = MODEL_REGISTRY[type_name]
     merged = _merge_params(defaults, override or {})
+    if type_name == "CatBoost":
+        merged = strip_catboost_gpu_incompatible_params(merged)
     if "name" not in merged:
         merged["name"] = f"{type_name}_{index}"
 

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -225,12 +225,44 @@ def run_trial(
             seed=seed,
         )
 
-    return EraSplitEvaluator(
+    diagnostics_state: dict[str, Any] = {}
+
+    def last_fold_callback(
+        predictor: Any, X_te: pd.DataFrame, y_te: pd.Series, era_te: pd.Series
+    ) -> None:
+        diagnostics_state["pipeline"] = predictor
+        diagnostics_state["X_val"] = X_te
+        diagnostics_state["y_val"] = y_te
+        diagnostics_state["era_val"] = era_te
+
+    metrics = EraSplitEvaluator(
         feature_columns=feature_cols,
         n_splits=WF_N_SPLITS,
         n_purge=WF_N_PURGE,
         min_train_eras=WF_MIN_TRAIN_ERAS,
-    ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)
+    ).evaluate_walk_forward(
+        X_train,
+        y_train,
+        era_train,
+        train_fn,
+        last_fold_callback=last_fold_callback
+        if config.get("log_wandb_diagnostics")
+        else None,
+    )
+    if config.get("log_wandb_diagnostics") and diagnostics_state:
+        from ..evaluation.wandb_diagnostics import log_experiment_diagnostics
+
+        log_experiment_diagnostics(
+            pipeline=diagnostics_state["pipeline"],
+            X_val=diagnostics_state["X_val"],
+            y_val=diagnostics_state["y_val"],
+            era_val=diagnostics_state["era_val"],
+            feature_cols=feature_cols,
+            metrics=metrics,
+            log_shap=bool(config.get("wandb_log_shap", True)),
+            compute_fnc=False,
+        )
+    return metrics
 
 
 def run_trial_fast_walk_forward(

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -93,8 +93,12 @@ def _fit_pipeline(
         pipeline_cfg, feature_columns=feature_cols, feature_groups=None
     )
     era_col = X_fit_src["era"] if "era" in X_fit_src.columns else None
+    stacking_needs_val = (
+        pipeline_cfg.get("ensemble_method") == "stacking"
+        and len(pipeline_cfg.get("models", [])) > 1
+    )
     X_fit, y_fit, X_val_inner, y_val_inner = internal_val_split(
-        X_fit_src, y_fit_src, era_train=era_col
+        X_fit_src, y_fit_src, era_train=era_col, force_internal=stacking_needs_val
     )
     pipeline.fit(X_fit, y_fit, X_val=X_val_inner, y_val=y_val_inner, **train_kwargs)
     return pipeline

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -15,6 +15,7 @@ from ..evaluation.era_split import (
     EraSplitEvaluator,
 )
 from ..experiments.split import internal_val_split
+from ..models.diffusion_augmenter import SyntheticDataAugmenter
 from .builder import build_pipeline_or_multi
 from .search_space import get_train_kwargs_from_flat, resolve_flat_config
 
@@ -37,19 +38,63 @@ def ray_trainable(config: dict[str, Any], **kwargs: Any) -> dict[str, float]:
     return run_trial(config, **kwargs)
 
 
+def _apply_synthetic_augmentation(
+    X_tr: pd.DataFrame,
+    y_tr: pd.Series,
+    flat_config: dict[str, Any],
+    feature_cols: list[str],
+    seed: int | None,
+) -> tuple[pd.DataFrame, pd.Series]:
+    aug = SyntheticDataAugmenter(
+        top_fraction=float(flat_config.get("augmenter_top_fraction", 0.10)),
+        n_synthetic=int(flat_config.get("augmenter_n_synthetic", 500)),
+        backend=str(flat_config.get("augmenter_backend", "auto")),
+        seed=int(seed or 42),
+    )
+    feat_cols = [c for c in feature_cols if c in X_tr.columns]
+    feat = X_tr[feat_cols]
+    aug.fit(feat, y_tr)
+    X_syn, y_syn = aug.generate()
+    syn_df = X_syn.copy()
+    if "era" in X_tr.columns:
+        rng = np.random.default_rng(seed)
+        train_eras = X_tr["era"].unique()
+        syn_df["era"] = rng.choice(train_eras, size=len(syn_df))
+    aligned = syn_df.reindex(columns=X_tr.columns, fill_value=0.0)
+    X_out = pd.concat([X_tr.reset_index(drop=True), aligned], ignore_index=True)
+    y_out = pd.concat(
+        [y_tr.reset_index(drop=True), y_syn.reset_index(drop=True)],
+        ignore_index=True,
+    )
+    y_out.name = y_tr.name or y_syn.name or "target"
+    if len(X_out) != len(y_out):
+        raise ValueError(
+            f"Augmented X/y length mismatch: {len(X_out)} rows vs {len(y_out)} labels"
+        )
+    return X_out, y_out
+
+
 def _fit_pipeline(
     pipeline_cfg: dict[str, Any],
     feature_cols: list[str],
     X_tr: pd.DataFrame,
     y_tr: pd.Series,
     train_kwargs: dict[str, Any],
+    flat_config: dict[str, Any] | None = None,
+    seed: int | None = None,
 ) -> Any:
+    X_fit_src = X_tr
+    y_fit_src = y_tr
+    if flat_config and flat_config.get("use_augmentation"):
+        X_fit_src, y_fit_src = _apply_synthetic_augmentation(
+            X_tr, y_tr, flat_config, feature_cols, seed
+        )
     pipeline = build_pipeline_or_multi(
         pipeline_cfg, feature_columns=feature_cols, feature_groups=None
     )
-    era_col = X_tr["era"] if "era" in X_tr.columns else None
+    era_col = X_fit_src["era"] if "era" in X_fit_src.columns else None
     X_fit, y_fit, X_val_inner, y_val_inner = internal_val_split(
-        X_tr, y_tr, era_train=era_col
+        X_fit_src, y_fit_src, era_train=era_col
     )
     pipeline.fit(X_fit, y_fit, X_val=X_val_inner, y_val=y_val_inner, **train_kwargs)
     return pipeline
@@ -64,6 +109,8 @@ def _evaluate_holdout(
     pipeline_cfg: dict[str, Any],
     train_kwargs: dict[str, Any],
     holdout_eras: int = HPO_FAST_HOLDOUT_ERAS,
+    config: dict[str, Any] | None = None,
+    seed: int | None = None,
 ) -> dict[str, float]:
     eras_sorted = sorted(era_train.unique(), key=str)
     min_train = WF_MIN_TRAIN_ERAS
@@ -82,13 +129,32 @@ def _evaluate_holdout(
         X_train.loc[train_mask],
         y_train.loc[train_mask],
         train_kwargs,
+        flat_config=config,
+        seed=seed,
     )
     ho_mask = era_train.isin(holdout_set)
-    return Backtester(pipeline, feature_columns=feature_cols).evaluate(
-        X_train.loc[ho_mask],
-        y_train.loc[ho_mask],
-        era_train.loc[ho_mask],
+    X_ho = X_train.loc[ho_mask]
+    y_ho = y_train.loc[ho_mask]
+    era_ho = era_train.loc[ho_mask]
+    metrics = Backtester(pipeline, feature_columns=feature_cols).evaluate(
+        X_ho,
+        y_ho,
+        era_ho,
     )
+    if config and config.get("log_wandb_diagnostics"):
+        from ..evaluation.wandb_diagnostics import log_experiment_diagnostics
+
+        log_experiment_diagnostics(
+            pipeline=pipeline,
+            X_val=X_ho,
+            y_val=y_ho,
+            era_val=era_ho,
+            feature_cols=feature_cols,
+            metrics=metrics,
+            log_shap=bool(config.get("wandb_log_shap", True)),
+            compute_fnc=False,
+        )
+    return metrics
 
 
 def run_trial(
@@ -144,10 +210,20 @@ def run_trial(
             feature_cols=feature_cols,
             pipeline_cfg=pipeline_cfg,
             train_kwargs=train_kwargs,
+            config=config,
+            seed=seed,
         )
 
     def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:
-        return _fit_pipeline(pipeline_cfg, feature_cols, X_tr, y_tr, train_kwargs)
+        return _fit_pipeline(
+            pipeline_cfg,
+            feature_cols,
+            X_tr,
+            y_tr,
+            train_kwargs,
+            flat_config=config,
+            seed=seed,
+        )
 
     return EraSplitEvaluator(
         feature_columns=feature_cols,
@@ -179,7 +255,15 @@ def run_trial_fast_walk_forward(
     train_kwargs = get_train_kwargs_from_flat(config)
 
     def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:
-        return _fit_pipeline(pipeline_cfg, feature_cols, X_tr, y_tr, train_kwargs)
+        return _fit_pipeline(
+            pipeline_cfg,
+            feature_cols,
+            X_tr,
+            y_tr,
+            train_kwargs,
+            flat_config=config,
+            seed=seed,
+        )
 
     return EraSplitEvaluator(
         feature_columns=feature_cols,

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -4,7 +4,11 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from ..evaluation.backtester import Backtester
 from ..evaluation.era_split import (
+    HPO_FAST_HOLDOUT_ERAS,
+    HPO_FAST_MAX_TRAIN_ERAS,
+    HPO_FAST_WF_N_SPLITS,
     WF_MIN_TRAIN_ERAS,
     WF_N_PURGE,
     WF_N_SPLITS,
@@ -33,6 +37,60 @@ def ray_trainable(config: dict[str, Any], **kwargs: Any) -> dict[str, float]:
     return run_trial(config, **kwargs)
 
 
+def _fit_pipeline(
+    pipeline_cfg: dict[str, Any],
+    feature_cols: list[str],
+    X_tr: pd.DataFrame,
+    y_tr: pd.Series,
+    train_kwargs: dict[str, Any],
+) -> Any:
+    pipeline = build_pipeline_or_multi(
+        pipeline_cfg, feature_columns=feature_cols, feature_groups=None
+    )
+    era_col = X_tr["era"] if "era" in X_tr.columns else None
+    X_fit, y_fit, X_val_inner, y_val_inner = internal_val_split(
+        X_tr, y_tr, era_train=era_col
+    )
+    pipeline.fit(X_fit, y_fit, X_val=X_val_inner, y_val=y_val_inner, **train_kwargs)
+    return pipeline
+
+
+def _evaluate_holdout(
+    *,
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    era_train: pd.Series,
+    feature_cols: list[str],
+    pipeline_cfg: dict[str, Any],
+    train_kwargs: dict[str, Any],
+    holdout_eras: int = HPO_FAST_HOLDOUT_ERAS,
+) -> dict[str, float]:
+    eras_sorted = sorted(era_train.unique(), key=str)
+    min_train = WF_MIN_TRAIN_ERAS
+    n_holdout = min(holdout_eras, max(5, len(eras_sorted) // 5))
+    if len(eras_sorted) <= min_train + n_holdout:
+        n_holdout = max(1, len(eras_sorted) // 5)
+
+    holdout_set = set(eras_sorted[-n_holdout:])
+    train_mask = ~era_train.isin(holdout_set)
+    if not train_mask.any():
+        return {"corr_sharpe": float("nan"), "mean_per_era_correlation": float("nan")}
+
+    pipeline = _fit_pipeline(
+        pipeline_cfg,
+        feature_cols,
+        X_train.loc[train_mask],
+        y_train.loc[train_mask],
+        train_kwargs,
+    )
+    ho_mask = era_train.isin(holdout_set)
+    return Backtester(pipeline, feature_columns=feature_cols).evaluate(
+        X_train.loc[ho_mask],
+        y_train.loc[ho_mask],
+        era_train.loc[ho_mask],
+    )
+
+
 def run_trial(
     config: dict[str, Any],
     *,
@@ -41,12 +99,13 @@ def run_trial(
     era_train: pd.Series,
     feature_cols: list[str],
     seed: int | None = None,
+    fast_eval: bool | None = None,
 ) -> dict[str, float]:
-    """Train a single HPO trial and return walk-forward backtest metrics.
+    """Train a single HPO trial and return backtest metrics.
 
-    Each trial retrains the model on expanding era windows (n_splits=3) so
-    that the returned metrics reflect out-of-sample temporal performance rather
-    than a fixed holdout split.
+    When ``fast_eval`` is True (default for ``hpo_fast`` configs), scores a
+    single holdout on the last ``HPO_FAST_HOLDOUT_ERAS`` eras instead of full
+    walk-forward CV. This keeps trials under the 30-minute budget on full data.
 
     Args:
         config: Flat parameter dictionary (as produced by
@@ -55,15 +114,59 @@ def run_trial(
         y_train: Training target Series.
         era_train: Era labels aligned to X_train.
         feature_cols: Feature column names (must not include "era").
-        seed: Optional integer seed for reproducibility. Pass a per-trial
-            value (e.g. trial number) rather than a fixed constant so that
-            parallel Ray workers do not share the same RNG state.
+        seed: Optional integer seed for reproducibility.
+        fast_eval: Override fast holdout mode. When None, reads ``hpo_fast``
+            from *config* (defaults to False).
 
     Returns:
-        Dictionary of walk-forward metrics (keys include ``corr_sharpe``,
+        Dictionary of backtest metrics (keys include ``corr_sharpe``,
         ``mean_per_era_correlation``, ``max_drawdown``, ``pct_positive_eras``,
         ``n_valid_eras``).
     """
+    if seed is not None:
+        rng = np.random.default_rng(seed)
+        np.random.seed(rng.integers(0, 2**31))
+
+    use_fast = fast_eval if fast_eval is not None else bool(config.get("hpo_fast"))
+
+    pipeline_cfg = resolve_flat_config(config)
+    if config.get("use_gpu"):
+        from .search_space import apply_gpu_pipeline_config
+
+        pipeline_cfg = apply_gpu_pipeline_config(pipeline_cfg)
+    train_kwargs = get_train_kwargs_from_flat(config)
+
+    if use_fast:
+        return _evaluate_holdout(
+            X_train=X_train,
+            y_train=y_train,
+            era_train=era_train,
+            feature_cols=feature_cols,
+            pipeline_cfg=pipeline_cfg,
+            train_kwargs=train_kwargs,
+        )
+
+    def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:
+        return _fit_pipeline(pipeline_cfg, feature_cols, X_tr, y_tr, train_kwargs)
+
+    return EraSplitEvaluator(
+        feature_columns=feature_cols,
+        n_splits=WF_N_SPLITS,
+        n_purge=WF_N_PURGE,
+        min_train_eras=WF_MIN_TRAIN_ERAS,
+    ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)
+
+
+def run_trial_fast_walk_forward(
+    config: dict[str, Any],
+    *,
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    era_train: pd.Series,
+    feature_cols: list[str],
+    seed: int | None = None,
+) -> dict[str, float]:
+    """Walk-forward with reduced folds and capped train window for HPO."""
     if seed is not None:
         rng = np.random.default_rng(seed)
         np.random.seed(rng.integers(0, 2**31))
@@ -76,23 +179,12 @@ def run_trial(
     train_kwargs = get_train_kwargs_from_flat(config)
 
     def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:
-        pipeline = build_pipeline_or_multi(
-            pipeline_cfg, feature_columns=feature_cols, feature_groups=None
-        )
-        era_col = X_tr["era"] if "era" in X_tr.columns else None
-        stacking_needs_val = (
-            pipeline_cfg.get("ensemble_method") == "stacking"
-            and len(pipeline_cfg.get("models", [])) > 1
-        )
-        X_fit, y_fit, X_val_inner, y_val_inner = internal_val_split(
-            X_tr, y_tr, era_train=era_col, force_internal=stacking_needs_val
-        )
-        pipeline.fit(X_fit, y_fit, X_val=X_val_inner, y_val=y_val_inner, **train_kwargs)
-        return pipeline
+        return _fit_pipeline(pipeline_cfg, feature_cols, X_tr, y_tr, train_kwargs)
 
     return EraSplitEvaluator(
         feature_columns=feature_cols,
-        n_splits=WF_N_SPLITS,
+        n_splits=HPO_FAST_WF_N_SPLITS,
         n_purge=WF_N_PURGE,
         min_train_eras=WF_MIN_TRAIN_ERAS,
+        max_train_eras=HPO_FAST_MAX_TRAIN_ERAS,
     ).evaluate_walk_forward(X_train, y_train, era_train, train_fn)

--- a/src/alphapulse/hpo/objective.py
+++ b/src/alphapulse/hpo/objective.py
@@ -69,6 +69,10 @@ def run_trial(
         np.random.seed(rng.integers(0, 2**31))
 
     pipeline_cfg = resolve_flat_config(config)
+    if config.get("use_gpu"):
+        from .search_space import apply_gpu_pipeline_config
+
+        pipeline_cfg = apply_gpu_pipeline_config(pipeline_cfg)
     train_kwargs = get_train_kwargs_from_flat(config)
 
     def train_fn(X_tr: pd.DataFrame, y_tr: pd.Series) -> Any:

--- a/src/alphapulse/hpo/registry.py
+++ b/src/alphapulse/hpo/registry.py
@@ -12,6 +12,7 @@ from ..models.lightgbm_model import LightGBMModel
 from ..models.packboost_model import PackboostModel
 from ..models.sklearn_models import ExtraTreesModel, RandomForestModel, RidgeModel
 from ..models.xgboost_model import XGBoostModel
+from ..preprocessors.autoencoder import AutoencoderPreprocessor
 from ..preprocessors.base import BasePreprocessor
 from ..preprocessors.compression import PCAPreprocessor, TruncatedSVDPreprocessor
 from ..preprocessors.era_stable import EraStableFeatureSelector
@@ -168,6 +169,10 @@ PREPROCESSOR_REGISTRY: dict[str, tuple[type[BasePreprocessor], dict[str, Any]]] 
     "TruncatedSVD": (
         TruncatedSVDPreprocessor,
         {"n_components": 10},
+    ),
+    "Autoencoder": (
+        AutoencoderPreprocessor,
+        {"latent_dim": 64},
     ),
     "VarianceSelector": (
         VarianceFeatureSelector,

--- a/src/alphapulse/hpo/search_space.py
+++ b/src/alphapulse/hpo/search_space.py
@@ -9,21 +9,55 @@ except ImportError:
 BOOSTING_MODELS = ["XGBoost", "LightGBM", "Packboost", "CatBoost"]
 FOUNDATION_MODELS = ["TabPFN", "TabICL", "TabPFN3", "TabPFN3Reasoning"]
 FOUNDATION_SAMPLE_PROB = 0.05
+AUGMENTER_SAMPLE_PROB = 0.05
 
 
-def _sample_model_type(
-    phase: str, rng: _random_mod.Random, exclude: frozenset[str] | None = None
-) -> str:
+def apply_gpu_model_params(model_type: str, params: dict[str, Any]) -> dict[str, Any]:
+    out = dict(params)
+    if model_type == "XGBoost":
+        inner = out.get("params")
+        if isinstance(inner, dict):
+            inner = dict(inner)
+            inner["device"] = "cuda"
+            out["params"] = inner
+        else:
+            out["device"] = "cuda"
+    elif model_type == "CatBoost":
+        inner = out.get("params")
+        if isinstance(inner, dict):
+            inner = dict(inner)
+            inner["task_type"] = "GPU"
+            inner.pop("colsample_bylevel", None)
+            out["params"] = inner
+        else:
+            out["task_type"] = "GPU"
+            out.pop("colsample_bylevel", None)
+    return out
+
+
+def apply_gpu_pipeline_config(config: dict[str, Any]) -> dict[str, Any]:
+    cfg = dict(config)
+    models = []
+    for item in cfg.get("models", []):
+        model_type = item.get("type", "")
+        params = dict(item.get("params") or {})
+        models.append(
+            {
+                **item,
+                "params": apply_gpu_model_params(model_type, params),
+            }
+        )
+    cfg["models"] = models
+    return cfg
+
+
+def _sample_model_type(phase: str, rng: _random_mod.Random) -> str:
     if phase != "phase_a":
         roll = rng.random()
         if roll < FOUNDATION_SAMPLE_PROB:
-            available = (
-                [m for m in FOUNDATION_MODELS if m not in exclude]
-                if exclude
-                else FOUNDATION_MODELS
-            )
-            if available:
-                return rng.choice(available)
+            return rng.choice(FOUNDATION_MODELS)
+        if roll < FOUNDATION_SAMPLE_PROB + AUGMENTER_SAMPLE_PROB:
+            return "SyntheticDataAugmenter"
     if phase == "phase_a":
         return rng.choice(["XGBoost", "LightGBM"])
     return rng.choice(BOOSTING_MODELS)
@@ -34,10 +68,7 @@ def _loguniform(low: float, high: float, rng: _random_mod.Random) -> float:
 
 
 def sample_random_config(
-    seed: int | None = None,
-    *,
-    phase: str = "phase_b",
-    exclude_models: frozenset[str] | None = None,
+    seed: int | None = None, *, phase: str = "phase_b"
 ) -> dict[str, Any]:
     """Sample a random flat HPO configuration for local search.
 
@@ -91,18 +122,10 @@ def sample_random_config(
         "packboost_boost_weight": rng.uniform(0.1, 0.5),
         "packboost_n_rounds_base": rng.choice([200, 300, 500]),
         "packboost_n_rounds_boost": rng.choice([100, 150, 200]),
-        "use_feature_selection": rng.choice([True, False]),
-        "feature_selection_type": rng.choice(
-            ["variance", "lgbm_importance", "era_stable"]
-        ),
-        "feature_selection_keep_fraction": rng.uniform(0.5, 0.9),
-        "era_stable_stability_weight": rng.uniform(0.3, 0.7),
-        "use_noise_injection": rng.choice([True, False]),
-        "noise_sigma": _loguniform(5e-3, 5e-2, rng),
         "num_models": rng.choice([1, 2, 3]),
-        "model_1_type": _sample_model_type("phase_b", rng, exclude_models),
-        "model_2_type": _sample_model_type("phase_b", rng, exclude_models),
-        "model_3_type": _sample_model_type("phase_b", rng, exclude_models),
+        "model_1_type": _sample_model_type("phase_b", rng),
+        "model_2_type": _sample_model_type("phase_b", rng),
+        "model_3_type": _sample_model_type("phase_b", rng),
         "n_subs": rng.choice([5, 8, 10, 15]),
         "xgb_max_depth": rng.choice([3, 5, 7]),
         "xgb_learning_rate": _loguniform(1e-3, 0.1, rng),
@@ -124,6 +147,10 @@ def sample_random_config(
         "augmenter_top_fraction": rng.uniform(0.05, 0.20),
         "augmenter_n_synthetic": rng.choice([200, 500, 1000]),
         "augmenter_backend": "auto",
+        "foundation_max_train_rows": rng.choice([5_000, 10_000, 20_000]),
+        "foundation_compression": rng.choice(["pca", "svd"]),
+        "foundation_n_components": rng.choice([128, 256, 512]),
+        "use_gpu": False,
     }
 
 
@@ -140,14 +167,6 @@ def get_full_param_space() -> dict[str, Any]:
         "packboost_boost_weight": tune.uniform(0.1, 0.5),
         "packboost_n_rounds_base": tune.choice([200, 300, 500]),
         "packboost_n_rounds_boost": tune.choice([100, 150, 200]),
-        "use_feature_selection": tune.choice([True, False]),
-        "feature_selection_type": tune.choice(
-            ["variance", "lgbm_importance", "era_stable"]
-        ),
-        "feature_selection_keep_fraction": tune.uniform(0.5, 0.9),
-        "era_stable_stability_weight": tune.uniform(0.3, 0.7),
-        "use_noise_injection": tune.choice([True, False]),
-        "noise_sigma": tune.loguniform(5e-3, 5e-2),
         "num_models": tune.choice([1, 2, 3]),
         "model_1_type": tune.choice(BOOSTING_MODELS + FOUNDATION_MODELS),
         "model_2_type": tune.choice(BOOSTING_MODELS + FOUNDATION_MODELS),
@@ -170,6 +189,9 @@ def get_full_param_space() -> dict[str, Any]:
         "stacking_meta_learner": tune.choice(["ridge", "xgboost"]),
         "use_neutralization": tune.choice([True, False]),
         "neutralization_proportion": tune.uniform(0.1, 0.8),
+        "foundation_max_train_rows": tune.choice([5_000, 10_000, 20_000]),
+        "foundation_compression": tune.choice(["pca", "svd"]),
+        "foundation_n_components": tune.choice([128, 256, 512]),
     }
 
 
@@ -207,51 +229,19 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
                 },
             }
         )
-    if flat.get("use_feature_selection"):
-        fs_type = flat.get("feature_selection_type", "variance")
-        keep = float(flat.get("feature_selection_keep_fraction", 0.75))
-        if fs_type == "lgbm_importance":
-            preprocessors.append(
-                {"type": "LGBMImportanceSelector", "params": {"keep_fraction": keep}}
-            )
-        elif fs_type == "era_stable":
-            preprocessors.append(
-                {
-                    "type": "EraStableSelector",
-                    "params": {
-                        "keep_fraction": keep,
-                        "stability_weight": float(
-                            flat.get("era_stable_stability_weight", 0.5)
-                        ),
-                    },
-                }
-            )
-        else:
-            preprocessors.append(
-                {
-                    "type": "VarianceSelector",
-                    "params": {"keep_fraction": keep, "mode": "quantile"},
-                }
-            )
-    if flat.get("use_noise_injection"):
-        preprocessors.append(
-            {
-                "type": "GaussianNoise",
-                "params": {"sigma": float(flat.get("noise_sigma", 0.01))},
-            }
-        )
 
     def model_params(t: str, index: int) -> dict[str, Any]:
         if t == "XGBoost":
-            return {
-                "params": {
-                    "max_depth": flat.get("xgb_max_depth", 5),
-                    "learning_rate": flat.get("xgb_learning_rate", 0.01),
-                    "tree_method": "hist",
-                    "objective": "reg:squarederror",
-                    "eval_metric": "rmse",
-                },
+            xgb_params = {
+                "max_depth": flat.get("xgb_max_depth", 5),
+                "learning_rate": flat.get("xgb_learning_rate", 0.01),
+                "tree_method": "hist",
+                "objective": "reg:squarederror",
+                "eval_metric": "rmse",
             }
+            if flat.get("use_gpu"):
+                xgb_params["device"] = "cuda"
+            return {"params": xgb_params}
         if t == "LightGBM":
             return {
                 "params": {
@@ -266,16 +256,23 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
                 "early_stopping_rounds": flat.get("lgbm_early_stopping", 100),
             }
         if t == "CatBoost":
+            cb_params = {
+                "depth": flat.get("catboost_depth", 6),
+                "learning_rate": flat.get("catboost_learning_rate", 0.03),
+                "l2_leaf_reg": flat.get("catboost_l2_leaf_reg", 5.0),
+                "min_data_in_leaf": flat.get("catboost_min_data_in_leaf", 200),
+                "loss_function": "RMSE",
+                "verbose": 0,
+                "allow_writing_files": False,
+            }
+            if flat.get("use_gpu"):
+                cb_params["task_type"] = "GPU"
+            else:
+                cb_params["colsample_bylevel"] = flat.get(
+                    "catboost_colsample_bylevel", 0.3
+                )
             return {
-                "params": {
-                    "depth": flat.get("catboost_depth", 6),
-                    "learning_rate": flat.get("catboost_learning_rate", 0.03),
-                    "l2_leaf_reg": flat.get("catboost_l2_leaf_reg", 5.0),
-                    "min_data_in_leaf": flat.get("catboost_min_data_in_leaf", 200),
-                    "loss_function": "RMSE",
-                    "verbose": 0,
-                    "allow_writing_files": False,
-                },
+                "params": cb_params,
                 "iterations": flat.get("catboost_iterations", 2000),
                 "early_stopping_rounds": flat.get("catboost_early_stopping", 100),
             }
@@ -308,8 +305,13 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
                 "n_rounds_base": flat.get("packboost_model_n_rounds_base", 500),
                 "n_rounds_boost": flat.get("packboost_model_n_rounds_boost", 200),
             }
-        if t in ("TabPFN", "TabPFN3", "TabICL", "TabPFN3Reasoning"):
-            return {}
+        if t in FOUNDATION_MODELS:
+            keys = {
+                "foundation_max_train_rows": "max_train_rows",
+                "foundation_compression": "compression",
+                "foundation_n_components": "compression_components",
+            }
+            return {param: flat[key] for key, param in keys.items() if key in flat}
         if t == "SyntheticDataAugmenter":
             return {
                 "top_fraction": flat.get("augmenter_top_fraction", 0.10),
@@ -318,13 +320,12 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
             }
         return {}
 
+    tree_models = {"XGBoost", "LightGBM", "CatBoost", "RandomForest", "ExtraTrees"}
     models = []
     for i, t in enumerate(types):
-        spec: dict[str, Any] = {
-            "type": t,
-            "params": model_params(t, i),
-            "use_era_ensemble": False,
-        }
+        spec: dict[str, Any] = {"type": t, "params": model_params(t, i)}
+        if t in tree_models:
+            spec["n_subs"] = flat.get("n_subs", 10)
         models.append(spec)
 
     ensemble_method = flat.get("ensemble_method", "single")

--- a/src/alphapulse/hpo/search_space.py
+++ b/src/alphapulse/hpo/search_space.py
@@ -12,9 +12,54 @@ BOOSTING_MODELS = ["XGBoost", "LightGBM", "Packboost", "CatBoost"]
 FOUNDATION_MODELS = ["TabPFN", "TabICL", "TabPFN3", "TabPFN3Reasoning"]
 FOUNDATION_SAMPLE_PROB = 0.05
 AUGMENTER_SAMPLE_PROB = 0.05
+HPO_FAST_FOUNDATION_SAMPLE_PROB = 0.03
+HPO_SLOW_FOUNDATION_TYPES = ("TabPFN3", "TabPFN3Reasoning")
+MIN_NEUTRALIZATION_PROPORTION = 0.15
+DEFAULT_NEUTRALIZATION_PROPORTION = 0.35
+NEUTRALIZATION_PROPORTION_RANGE = (MIN_NEUTRALIZATION_PROPORTION, 0.8)
 
 
-def available_foundation_models() -> list[str]:
+def uses_neutralization_for_models(model_types: list[str]) -> bool:
+    return not any(t in FOUNDATION_MODELS for t in model_types)
+
+
+def _sampled_model_types(cfg: dict[str, Any]) -> list[str]:
+    num_models = int(cfg.get("num_models", 1))
+    return [
+        str(cfg.get("model_1_type", "XGBoost")),
+        str(cfg.get("model_2_type", "XGBoost")),
+        str(cfg.get("model_3_type", "XGBoost")),
+    ][:num_models]
+
+
+def _finalize_neutralization_sampling(cfg: dict[str, Any]) -> dict[str, Any]:
+    types = _sampled_model_types(cfg)
+    if uses_neutralization_for_models(types):
+        cfg["use_neutralization"] = True
+        proportion = float(
+            cfg.get("neutralization_proportion", DEFAULT_NEUTRALIZATION_PROPORTION)
+        )
+        cfg["neutralization_proportion"] = max(
+            MIN_NEUTRALIZATION_PROPORTION, proportion
+        )
+    else:
+        cfg["use_neutralization"] = False
+        cfg["neutralization_proportion"] = 0.0
+    return cfg
+
+
+def resolve_neutralize_proportion(
+    flat: dict[str, Any], model_types: list[str]
+) -> float:
+    if not uses_neutralization_for_models(model_types):
+        return 0.0
+    proportion = float(
+        flat.get("neutralization_proportion", DEFAULT_NEUTRALIZATION_PROPORTION)
+    )
+    return max(MIN_NEUTRALIZATION_PROPORTION, min(1.0, proportion))
+
+
+def available_foundation_models(*, hpo_fast: bool = False) -> list[str]:
     available: list[str] = []
     try:
         import tabpfn  # noqa: F401
@@ -37,6 +82,8 @@ def available_foundation_models() -> list[str]:
             available.append("TabPFN3Reasoning")
         except ImportError:
             pass
+    if hpo_fast:
+        return [m for m in available if m not in HPO_SLOW_FOUNDATION_TYPES]
     return available
 
 
@@ -98,15 +145,18 @@ def apply_gpu_pipeline_config(config: dict[str, Any]) -> dict[str, Any]:
     return cfg
 
 
-def _sample_model_type(phase: str, rng: _random_mod.Random) -> str:
+def _sample_model_type(
+    phase: str, rng: _random_mod.Random, *, fast: bool = False
+) -> str:
     if phase != "phase_a":
         roll = rng.random()
-        if roll < FOUNDATION_SAMPLE_PROB:
-            foundation_models = available_foundation_models()
+        foundation_prob = (
+            HPO_FAST_FOUNDATION_SAMPLE_PROB if fast else FOUNDATION_SAMPLE_PROB
+        )
+        if roll < foundation_prob:
+            foundation_models = available_foundation_models(hpo_fast=fast)
             if foundation_models:
                 return rng.choice(foundation_models)
-        if roll < FOUNDATION_SAMPLE_PROB + AUGMENTER_SAMPLE_PROB:
-            return "SyntheticDataAugmenter"
     if phase == "phase_a":
         return rng.choice(["XGBoost", "LightGBM"])
     return rng.choice(BOOSTING_MODELS)
@@ -143,9 +193,9 @@ def sample_random_config(
             "packboost_n_rounds_base": 200,
             "packboost_n_rounds_boost": 100,
             "num_models": 1,
-            "model_1_type": _sample_model_type("phase_a", rng),
-            "model_2_type": _sample_model_type("phase_a", rng),
-            "model_3_type": _sample_model_type("phase_a", rng),
+            "model_1_type": _sample_model_type("phase_a", rng, fast=fast),
+            "model_2_type": _sample_model_type("phase_a", rng, fast=fast),
+            "model_3_type": _sample_model_type("phase_a", rng, fast=fast),
             "n_subs": rng.choice([8, 10]),
             "xgb_max_depth": rng.choice([3, 5]),
             "xgb_learning_rate": _loguniform(3e-3, 0.05, rng),
@@ -162,15 +212,15 @@ def sample_random_config(
             "packboost_model_n_rounds_boost": 100,
             "ensemble_method": "single",
             "stacking_meta_learner": "ridge",
-            "use_neutralization": False,
-            "neutralization_proportion": 0.5,
+            "use_neutralization": True,
+            "neutralization_proportion": rng.uniform(*NEUTRALIZATION_PROPORTION_RANGE),
         }
         if fast:
             cfg["hpo_fast"] = True
             cfg["n_subs"] = rng.choice([3, 5])
             cfg["xgb_n_rounds"] = rng.choice([150, 250, 350])
             cfg["lgbm_n_rounds"] = rng.choice([200, 400, 600])
-        return cfg
+        return _finalize_neutralization_sampling(cfg)
 
     cfg = {
         "scaler_type": rng.choice(["StandardScaler", "RobustScaler"]),
@@ -180,9 +230,9 @@ def sample_random_config(
         "packboost_n_rounds_base": rng.choice([200, 300, 500]),
         "packboost_n_rounds_boost": rng.choice([100, 150, 200]),
         "num_models": rng.choice([1, 2, 3]),
-        "model_1_type": _sample_model_type("phase_b", rng),
-        "model_2_type": _sample_model_type("phase_b", rng),
-        "model_3_type": _sample_model_type("phase_b", rng),
+        "model_1_type": _sample_model_type("phase_b", rng, fast=fast),
+        "model_2_type": _sample_model_type("phase_b", rng, fast=fast),
+        "model_3_type": _sample_model_type("phase_b", rng, fast=fast),
         "n_subs": rng.choice([5, 8, 10, 15]),
         "xgb_max_depth": rng.choice([3, 5, 7]),
         "xgb_learning_rate": _loguniform(1e-3, 0.1, rng),
@@ -199,14 +249,12 @@ def sample_random_config(
         "packboost_model_n_rounds_boost": rng.choice([100, 200]),
         "ensemble_method": rng.choice(["single", "weighted", "stacking"]),
         "stacking_meta_learner": rng.choice(["ridge", "xgboost"]),
-        "use_neutralization": rng.choice([True, False]),
-        "neutralization_proportion": rng.uniform(0.1, 0.8),
+        "use_neutralization": True,
+        "neutralization_proportion": rng.uniform(*NEUTRALIZATION_PROPORTION_RANGE),
         "augmenter_top_fraction": rng.uniform(0.05, 0.20),
         "augmenter_n_synthetic": rng.choice([200, 500, 1000]),
         "augmenter_backend": "auto",
-        "foundation_max_train_rows": rng.choice([5_000, 10_000, 20_000]),
-        "foundation_compression": rng.choice(["pca", "svd"]),
-        "foundation_n_components": rng.choice([128, 256, 512]),
+        "use_augmentation": rng.random() < 0.05,
         "use_gpu": False,
     }
     if fast:
@@ -220,9 +268,13 @@ def sample_random_config(
         cfg["packboost_n_rounds_base"] = rng.choice([150, 250, 350])
         cfg["packboost_model_n_rounds_base"] = rng.choice([200, 300])
         cfg["foundation_max_train_rows"] = rng.choice([3_000, 5_000, 8_000])
+        cfg["foundation_compression"] = rng.choice(["autoencoder", "pca", "svd"])
         cfg["foundation_n_components"] = rng.choice([64, 128, 256])
+        cfg["foundation_n_estimators"] = rng.choice([2, 4])
+        cfg["foundation_compression_epochs"] = rng.choice([5, 10])
         cfg["use_packboost"] = False
-    return cfg
+        cfg["use_augmentation"] = rng.random() < 0.03
+    return _finalize_neutralization_sampling(cfg)
 
 
 def get_full_param_space() -> dict[str, Any]:
@@ -284,6 +336,9 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
         flat.get("model_2_type", "XGBoost"),
         flat.get("model_3_type", "XGBoost"),
     ][:num_models]
+    types = [t for t in types if t != "SyntheticDataAugmenter"]
+    if not types:
+        types = ["XGBoost"]
 
     preprocessors: list[dict[str, Any]] = [
         {"type": flat.get("scaler_type", "StandardScaler"), "params": {}}
@@ -382,18 +437,20 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
                 "n_rounds_boost": flat.get("packboost_model_n_rounds_boost", 200),
             }
         if t in FOUNDATION_MODELS:
-            keys = {
+            key_map = {
                 "foundation_max_train_rows": "max_train_rows",
                 "foundation_compression": "compression",
                 "foundation_n_components": "compression_components",
+                "foundation_n_estimators": "n_estimators",
+                "foundation_compression_epochs": "compression_epochs",
             }
-            return {param: flat[key] for key, param in keys.items() if key in flat}
-        if t == "SyntheticDataAugmenter":
-            return {
-                "top_fraction": flat.get("augmenter_top_fraction", 0.10),
-                "n_synthetic": flat.get("augmenter_n_synthetic", 500),
-                "backend": flat.get("augmenter_backend", "auto"),
-            }
+            params = {param: flat[key] for key, param in key_map.items() if key in flat}
+            if flat.get("hpo_fast") and "compression" not in params:
+                params["compression"] = "autoencoder"
+            if flat.get("use_gpu"):
+                params["device"] = "cuda"
+                params["compression_device"] = "cuda"
+            return params
         return {}
 
     tree_models = {"XGBoost", "LightGBM", "CatBoost", "RandomForest", "ExtraTrees"}
@@ -418,11 +475,7 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
         ensemble_params["meta_learner"] = flat.get("stacking_meta_learner", "ridge")
         ensemble_params["meta_params"] = {}
 
-    neutralize_proportion = (
-        float(flat.get("neutralization_proportion", 0.5))
-        if flat.get("use_neutralization")
-        else 0.0
-    )
+    neutralize_proportion = resolve_neutralize_proportion(flat, types)
 
     return {
         "preprocessors": preprocessors,

--- a/src/alphapulse/hpo/search_space.py
+++ b/src/alphapulse/hpo/search_space.py
@@ -12,6 +12,32 @@ FOUNDATION_SAMPLE_PROB = 0.05
 AUGMENTER_SAMPLE_PROB = 0.05
 
 
+def available_foundation_models() -> list[str]:
+    available: list[str] = []
+    try:
+        import tabpfn  # noqa: F401
+
+        available.extend(["TabPFN", "TabPFN3"])
+    except ImportError:
+        pass
+    try:
+        import tabicl  # noqa: F401
+
+        available.append("TabICL")
+    except ImportError:
+        pass
+    import os
+
+    if os.environ.get("TABPFN_API_KEY"):
+        try:
+            import tabpfn_client  # noqa: F401
+
+            available.append("TabPFN3Reasoning")
+        except ImportError:
+            pass
+    return available
+
+
 def apply_gpu_model_params(model_type: str, params: dict[str, Any]) -> dict[str, Any]:
     out = dict(params)
     if model_type == "XGBoost":
@@ -35,6 +61,16 @@ def apply_gpu_model_params(model_type: str, params: dict[str, Any]) -> dict[str,
     return out
 
 
+def strip_catboost_gpu_incompatible_params(params: dict[str, Any]) -> dict[str, Any]:
+    out = dict(params)
+    inner = out.get("params")
+    if isinstance(inner, dict) and inner.get("task_type") == "GPU":
+        inner = dict(inner)
+        inner.pop("colsample_bylevel", None)
+        out["params"] = inner
+    return out
+
+
 def apply_gpu_pipeline_config(config: dict[str, Any]) -> dict[str, Any]:
     cfg = dict(config)
     models = []
@@ -55,7 +91,9 @@ def _sample_model_type(phase: str, rng: _random_mod.Random) -> str:
     if phase != "phase_a":
         roll = rng.random()
         if roll < FOUNDATION_SAMPLE_PROB:
-            return rng.choice(FOUNDATION_MODELS)
+            foundation_models = available_foundation_models()
+            if foundation_models:
+                return rng.choice(foundation_models)
         if roll < FOUNDATION_SAMPLE_PROB + AUGMENTER_SAMPLE_PROB:
             return "SyntheticDataAugmenter"
     if phase == "phase_a":

--- a/src/alphapulse/hpo/search_space.py
+++ b/src/alphapulse/hpo/search_space.py
@@ -48,6 +48,15 @@ def apply_gpu_model_params(model_type: str, params: dict[str, Any]) -> dict[str,
             out["params"] = inner
         else:
             out["device"] = "cuda"
+    elif model_type == "LightGBM":
+        inner = out.get("params")
+        if isinstance(inner, dict):
+            inner = dict(inner)
+            inner["device"] = "gpu"
+            inner["gpu_platform_id"] = 0
+            inner["gpu_device_id"] = 0
+            inner.pop("n_jobs", None)
+            out["params"] = inner
     elif model_type == "CatBoost":
         inner = out.get("params")
         if isinstance(inner, dict):
@@ -281,15 +290,20 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
                 xgb_params["device"] = "cuda"
             return {"params": xgb_params}
         if t == "LightGBM":
+            lgb_params: dict[str, Any] = {
+                "num_leaves": flat.get("lgbm_num_leaves", 31),
+                "learning_rate": flat.get("lgbm_learning_rate", 0.01),
+                "min_child_samples": flat.get("lgbm_min_child_samples", 200),
+                "objective": "regression",
+                "metric": "rmse",
+                "verbosity": -1,
+            }
+            if flat.get("use_gpu"):
+                lgb_params["device"] = "gpu"
+                lgb_params["gpu_platform_id"] = 0
+                lgb_params["gpu_device_id"] = 0
             return {
-                "params": {
-                    "num_leaves": flat.get("lgbm_num_leaves", 31),
-                    "learning_rate": flat.get("lgbm_learning_rate", 0.01),
-                    "min_child_samples": flat.get("lgbm_min_child_samples", 200),
-                    "objective": "regression",
-                    "metric": "rmse",
-                    "verbosity": -1,
-                },
+                "params": lgb_params,
                 "n_estimators": flat.get("lgbm_n_rounds", 2000),
                 "early_stopping_rounds": flat.get("lgbm_early_stopping", 100),
             }

--- a/src/alphapulse/hpo/search_space.py
+++ b/src/alphapulse/hpo/search_space.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     tune = None
 
+from ..evaluation.era_split import HPO_FAST_N_SUBS_CAP
+
 BOOSTING_MODELS = ["XGBoost", "LightGBM", "Packboost", "CatBoost"]
 FOUNDATION_MODELS = ["TabPFN", "TabICL", "TabPFN3", "TabPFN3Reasoning"]
 FOUNDATION_SAMPLE_PROB = 0.05
@@ -115,7 +117,7 @@ def _loguniform(low: float, high: float, rng: _random_mod.Random) -> float:
 
 
 def sample_random_config(
-    seed: int | None = None, *, phase: str = "phase_b"
+    seed: int | None = None, *, phase: str = "phase_b", fast: bool = False
 ) -> dict[str, Any]:
     """Sample a random flat HPO configuration for local search.
 
@@ -123,6 +125,8 @@ def sample_random_config(
         seed: Random seed for reproducibility. *None* for non-deterministic.
         phase: Search phase (``"phase_a"`` for conservative exploration,
             ``"phase_b"`` for full search space).
+        fast: When True, sample tighter hyperparameters for sub-30-minute trials
+            on full data (lower rounds, fewer era subs, smaller foundation caps).
 
     Returns:
         Flat dictionary of hyperparameter values consumable by
@@ -131,7 +135,7 @@ def sample_random_config(
     rng = _random_mod.Random(seed)
 
     if phase == "phase_a":
-        return {
+        cfg = {
             "scaler_type": rng.choice(["StandardScaler", "RobustScaler"]),
             "use_packboost": False,
             "packboost_n_worst_eras": 3,
@@ -161,8 +165,14 @@ def sample_random_config(
             "use_neutralization": False,
             "neutralization_proportion": 0.5,
         }
+        if fast:
+            cfg["hpo_fast"] = True
+            cfg["n_subs"] = rng.choice([3, 5])
+            cfg["xgb_n_rounds"] = rng.choice([150, 250, 350])
+            cfg["lgbm_n_rounds"] = rng.choice([200, 400, 600])
+        return cfg
 
-    return {
+    cfg = {
         "scaler_type": rng.choice(["StandardScaler", "RobustScaler"]),
         "use_packboost": rng.choice([True, False]),
         "packboost_n_worst_eras": rng.choice([3, 5, 7]),
@@ -199,6 +209,20 @@ def sample_random_config(
         "foundation_n_components": rng.choice([128, 256, 512]),
         "use_gpu": False,
     }
+    if fast:
+        cfg["hpo_fast"] = True
+        cfg["num_models"] = rng.choice([1, 2])
+        cfg["n_subs"] = rng.choice([3, 5])
+        cfg["xgb_n_rounds"] = rng.choice([150, 250, 400])
+        cfg["xgb_early_stopping"] = rng.choice([20, 30, 50])
+        cfg["lgbm_n_rounds"] = rng.choice([200, 400, 600])
+        cfg["lgbm_early_stopping"] = rng.choice([30, 50])
+        cfg["packboost_n_rounds_base"] = rng.choice([150, 250, 350])
+        cfg["packboost_model_n_rounds_base"] = rng.choice([200, 300])
+        cfg["foundation_max_train_rows"] = rng.choice([3_000, 5_000, 8_000])
+        cfg["foundation_n_components"] = rng.choice([64, 128, 256])
+        cfg["use_packboost"] = False
+    return cfg
 
 
 def get_full_param_space() -> dict[str, Any]:
@@ -373,11 +397,15 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
         return {}
 
     tree_models = {"XGBoost", "LightGBM", "CatBoost", "RandomForest", "ExtraTrees"}
+    n_subs_cap = HPO_FAST_N_SUBS_CAP if flat.get("hpo_fast") else None
     models = []
     for i, t in enumerate(types):
         spec: dict[str, Any] = {"type": t, "params": model_params(t, i)}
         if t in tree_models:
-            spec["n_subs"] = flat.get("n_subs", 10)
+            n_subs = int(flat.get("n_subs", 10))
+            if n_subs_cap is not None:
+                n_subs = min(n_subs, n_subs_cap)
+            spec["n_subs"] = n_subs
         models.append(spec)
 
     ensemble_method = flat.get("ensemble_method", "single")

--- a/src/alphapulse/hpo/search_space.py
+++ b/src/alphapulse/hpo/search_space.py
@@ -20,7 +20,7 @@ NEUTRALIZATION_PROPORTION_RANGE = (MIN_NEUTRALIZATION_PROPORTION, 0.8)
 
 
 def uses_neutralization_for_models(model_types: list[str]) -> bool:
-    return not any(t in FOUNDATION_MODELS for t in model_types)
+    return any(t not in FOUNDATION_MODELS for t in model_types)
 
 
 def _sampled_model_types(cfg: dict[str, Any]) -> list[str]:
@@ -53,10 +53,31 @@ def resolve_neutralize_proportion(
 ) -> float:
     if not uses_neutralization_for_models(model_types):
         return 0.0
+    if not flat.get("use_neutralization", True):
+        return 0.0
     proportion = float(
         flat.get("neutralization_proportion", DEFAULT_NEUTRALIZATION_PROPORTION)
     )
     return max(MIN_NEUTRALIZATION_PROPORTION, min(1.0, proportion))
+
+
+def _torch_available() -> bool:
+    try:
+        import torch  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def resolve_foundation_compression(
+    compression: str | None, *, hpo_fast: bool = False
+) -> str | None:
+    if compression is None and hpo_fast:
+        compression = "autoencoder"
+    if compression == "autoencoder" and not _torch_available():
+        return "pca"
+    return compression
 
 
 def available_foundation_models(*, hpo_fast: bool = False) -> list[str]:
@@ -445,8 +466,11 @@ def resolve_flat_config(flat: dict[str, Any]) -> dict[str, Any]:
                 "foundation_compression_epochs": "compression_epochs",
             }
             params = {param: flat[key] for key, param in key_map.items() if key in flat}
-            if flat.get("hpo_fast") and "compression" not in params:
-                params["compression"] = "autoencoder"
+            compression = resolve_foundation_compression(
+                params.get("compression"), hpo_fast=bool(flat.get("hpo_fast"))
+            )
+            if compression is not None:
+                params["compression"] = compression
             if flat.get("use_gpu"):
                 params["device"] = "cuda"
                 params["compression_device"] = "cuda"

--- a/src/alphapulse/hpo/trial_db.py
+++ b/src/alphapulse/hpo/trial_db.py
@@ -34,11 +34,26 @@ class TrialDB:
         self._conn.commit()
 
     def insert_trial(self, trial_number: int, flat_config: dict[str, Any]) -> None:
-        self._conn.execute(
-            "INSERT OR IGNORE INTO trials (trial_number, status, flat_config) "
-            "VALUES (?, 'running', ?)",
-            (trial_number, json.dumps(flat_config)),
-        )
+        """Record a trial as running, replacing stale rows for failed retries."""
+        existing = self._conn.execute(
+            "SELECT status FROM trials WHERE trial_number=?",
+            (trial_number,),
+        ).fetchone()
+        if existing is not None:
+            if existing[0] == "completed":
+                return
+            self._conn.execute(
+                "UPDATE trials SET status='running', flat_config=?, "
+                "metrics=NULL, error=NULL, elapsed_seconds=NULL "
+                "WHERE trial_number=?",
+                (json.dumps(flat_config), trial_number),
+            )
+        else:
+            self._conn.execute(
+                "INSERT INTO trials (trial_number, status, flat_config) "
+                "VALUES (?, 'running', ?)",
+                (trial_number, json.dumps(flat_config)),
+            )
         self._conn.commit()
 
     def update_trial(

--- a/src/alphapulse/logging_/wandb_utils.py
+++ b/src/alphapulse/logging_/wandb_utils.py
@@ -150,6 +150,35 @@ def log_hpo_summary_table(
     wandb.finish(quiet=True)
 
 
+def log_hpo_trial_metrics(
+    result: "TrialResult",
+    objective: float,
+    *,
+    model_types: str | None = None,
+    preprocessors: str | None = None,
+) -> None:
+    import wandb
+
+    logged: dict[str, Any] = {
+        "sharpe": result.sharpe,
+        "objective": objective,
+        "elapsed_seconds": result.elapsed_seconds,
+    }
+    if model_types is not None:
+        logged["model_types"] = model_types
+    if preprocessors is not None:
+        logged["preprocessors"] = preprocessors
+    if result.corr_sharpe not in (float("-inf"), float("inf")):
+        logged["corr_sharpe"] = result.corr_sharpe
+    if result.mmc_sharpe is not None:
+        logged["mmc_sharpe"] = result.mmc_sharpe
+    if result.payout_score is not None:
+        logged["payout_score"] = result.payout_score
+    for k, v in (result.metrics or {}).items():
+        logged[f"metric/{k}"] = v
+    wandb.log(logged)
+
+
 def log_hpo_trial(
     result: "TrialResult",
     flat_config: dict[str, Any],
@@ -187,21 +216,7 @@ def log_hpo_trial(
         reinit=True,
     )
 
-    logged: dict[str, Any] = {
-        "sharpe": result.sharpe,
-        "objective": objective,
-        "elapsed_seconds": result.elapsed_seconds,
-        "model_types": model_types,
-        "preprocessors": preprocessors,
-    }
-    if result.corr_sharpe not in (float("-inf"), float("inf")):
-        logged["corr_sharpe"] = result.corr_sharpe
-    if result.mmc_sharpe is not None:
-        logged["mmc_sharpe"] = result.mmc_sharpe
-    if result.payout_score is not None:
-        logged["payout_score"] = result.payout_score
-    for k, v in (result.metrics or {}).items():
-        logged[f"metric/{k}"] = v
-
-    wandb.log(logged)
+    log_hpo_trial_metrics(
+        result, objective, model_types=model_types, preprocessors=preprocessors
+    )
     wandb.finish(quiet=True)

--- a/src/alphapulse/models/catboost_model.py
+++ b/src/alphapulse/models/catboost_model.py
@@ -52,6 +52,8 @@ class CatBoostModel(BaseModel):
         )
 
         full_params = {**self.params, "iterations": iters}
+        if full_params.get("task_type") == "GPU":
+            full_params.pop("colsample_bylevel", None)
         cb_model = CatBoostRegressor(**full_params)
 
         feat_train = _numeric(X_train)

--- a/src/alphapulse/models/factory.py
+++ b/src/alphapulse/models/factory.py
@@ -104,6 +104,11 @@ class ModelFactory:
             "verbosity": -1,
             "n_jobs": -1,
         }
+        if self.use_gpu:
+            params["device"] = "gpu"
+            params["gpu_platform_id"] = 0
+            params["gpu_device_id"] = 0
+            params.pop("n_jobs", None)
         n_est = trial.suggest_int(self._p("lgb_n_estimators"), 200, 2000, step=100)
         n_subs = trial.suggest_int(self._p("n_subs"), 5, 20)
         base_name = f"LGB_{n_est}r"

--- a/src/alphapulse/models/factory.py
+++ b/src/alphapulse/models/factory.py
@@ -14,9 +14,12 @@ ALL_MODEL_TYPES = TREE_MODEL_TYPES + ("ft_transformer", "mlp", "ridge")
 
 
 class ModelFactory:
-    def __init__(self, *, include_dl: bool = False, prefix: str = "model") -> None:
+    def __init__(
+        self, *, include_dl: bool = False, prefix: str = "model", use_gpu: bool = False
+    ) -> None:
         self.include_dl = include_dl
         self.prefix = prefix
+        self.use_gpu = use_gpu
 
     def _p(self, name: str) -> str:
         return f"{self.prefix}_{name}"
@@ -65,6 +68,8 @@ class ModelFactory:
             "objective": "reg:squarederror",
             "eval_metric": "rmse",
         }
+        if self.use_gpu:
+            params["device"] = "cuda"
         n_rounds = trial.suggest_int(self._p("xgb_n_rounds"), 200, 2000, step=100)
         n_subs = trial.suggest_int(self._p("n_subs"), 5, 20)
         base_name = f"XGB_{n_rounds}r"
@@ -121,11 +126,16 @@ class ModelFactory:
             "bagging_temperature": trial.suggest_float(
                 self._p("cb_bagging_temp"), 0.0, 1.0
             ),
-            "colsample_bylevel": trial.suggest_float(self._p("cb_colsample"), 0.1, 0.5),
             "verbose": 0,
             "thread_count": -1,
             "allow_writing_files": False,
         }
+        if self.use_gpu:
+            params["task_type"] = "GPU"
+        else:
+            params["colsample_bylevel"] = trial.suggest_float(
+                self._p("cb_colsample"), 0.1, 0.5
+            )
         iters = trial.suggest_int(self._p("cb_iterations"), 200, 2000, step=100)
         n_subs = trial.suggest_int(self._p("n_subs"), 5, 20)
         base_name = f"CB_{iters}i"

--- a/src/alphapulse/models/foundation_models.py
+++ b/src/alphapulse/models/foundation_models.py
@@ -15,7 +15,8 @@ from .sklearn_models import _load_sklearn, _save_sklearn
 COMPRESSION_METHODS = ("pca", "svd", "autoencoder")
 DEFAULT_COMPRESSION = "pca"
 DEFAULT_SEED = 42
-PREDICT_CHUNK_ROWS = 50_000
+DEFAULT_PREDICT_CHUNK_ROWS = 256
+PREDICT_CHUNK_ROWS = DEFAULT_PREDICT_CHUNK_ROWS
 
 TABPFN_MAX_TRAIN_ROWS = 10_000
 TABPFN_MAX_FEATURES = 500
@@ -25,6 +26,9 @@ TABPFN3_REASONING_MAX_TRAIN_ROWS = 10_000
 TABPFN3_REASONING_MAX_FEATURES = 500
 TABICL_MAX_TRAIN_ROWS = 60_000
 TABICL_MAX_FEATURES = 500
+TABPFN_PREDICT_CHUNK_ROWS = 256
+TABPFN3_PREDICT_CHUNK_ROWS = 128
+TABICL_PREDICT_CHUNK_ROWS = 2_048
 
 
 def _build_compressor(method: str, n_components: int, seed: int) -> BasePreprocessor:
@@ -57,6 +61,7 @@ class FoundationModel(BaseModel):
         max_features: int,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        predict_chunk_rows: int = DEFAULT_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = None,
     ) -> None:
@@ -65,6 +70,10 @@ class FoundationModel(BaseModel):
             raise ValueError(f"max_train_rows must be positive, got {max_train_rows}")
         if max_features < 1:
             raise ValueError(f"max_features must be positive, got {max_features}")
+        if predict_chunk_rows < 1:
+            raise ValueError(
+                f"predict_chunk_rows must be positive, got {predict_chunk_rows}"
+            )
         if compression is not None and compression not in COMPRESSION_METHODS:
             raise ValueError(
                 f"Unknown compression method: {compression!r}. "
@@ -74,6 +83,7 @@ class FoundationModel(BaseModel):
         self.max_features = max_features
         self.compression = compression
         self.compression_components = compression_components
+        self.predict_chunk_rows = predict_chunk_rows
         self.seed = seed
         self._compressor: BasePreprocessor | None = None
         self._medians: pd.Series | None = None
@@ -99,12 +109,13 @@ class FoundationModel(BaseModel):
     def predict(self, X: pd.DataFrame) -> np.ndarray:
         self._require_trained()
         feat = self._prepare_predict(X)
+        chunk_rows = self.predict_chunk_rows
         chunks = [
             np.asarray(
-                self.model.predict(feat.iloc[start : start + PREDICT_CHUNK_ROWS]),
+                self.model.predict(feat.iloc[start : start + chunk_rows]),
                 dtype=np.float64,
             )
-            for start in range(0, len(feat), PREDICT_CHUNK_ROWS)
+            for start in range(0, len(feat), chunk_rows)
         ]
         return np.concatenate(chunks) if chunks else np.empty(0, dtype=np.float64)
 
@@ -180,6 +191,7 @@ class TabPFNModel(FoundationModel):
         max_features: int = TABPFN_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        predict_chunk_rows: int = TABPFN_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN",
     ) -> None:
@@ -188,6 +200,7 @@ class TabPFNModel(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            predict_chunk_rows=predict_chunk_rows,
             seed=seed,
             name=name,
         )
@@ -224,6 +237,7 @@ class TabPFN3Model(FoundationModel):
         max_features: int = TABPFN3_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        predict_chunk_rows: int = TABPFN3_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN3",
     ) -> None:
@@ -232,6 +246,7 @@ class TabPFN3Model(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            predict_chunk_rows=predict_chunk_rows,
             seed=seed,
             name=name,
         )
@@ -326,6 +341,7 @@ class TabICLModel(FoundationModel):
         max_features: int = TABICL_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        predict_chunk_rows: int = TABPFN_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabICL",
     ) -> None:
@@ -334,6 +350,7 @@ class TabICLModel(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            predict_chunk_rows=predict_chunk_rows,
             seed=seed,
             name=name,
         )

--- a/src/alphapulse/models/foundation_models.py
+++ b/src/alphapulse/models/foundation_models.py
@@ -31,13 +31,22 @@ TABPFN3_PREDICT_CHUNK_ROWS = 128
 TABICL_PREDICT_CHUNK_ROWS = 2_048
 
 
-def _build_compressor(method: str, n_components: int, seed: int) -> BasePreprocessor:
+def _build_compressor(
+    method: str,
+    n_components: int,
+    seed: int,
+    *,
+    epochs: int = 20,
+    device: str | None = None,
+) -> BasePreprocessor:
     if method == "pca":
         return PCAPreprocessor(n_components=n_components, random_state=seed)
     if method == "svd":
         return TruncatedSVDPreprocessor(n_components=n_components, random_state=seed)
     if method == "autoencoder":
-        return AutoencoderPreprocessor(latent_dim=n_components, seed=seed)
+        return AutoencoderPreprocessor(
+            latent_dim=n_components, seed=seed, epochs=epochs, device=device
+        )
     raise ValueError(
         f"Unknown compression method: {method!r}. "
         f"Expected one of {COMPRESSION_METHODS}."
@@ -61,6 +70,8 @@ class FoundationModel(BaseModel):
         max_features: int,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        compression_epochs: int = 20,
+        compression_device: str | None = None,
         predict_chunk_rows: int = DEFAULT_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = None,
@@ -83,6 +94,8 @@ class FoundationModel(BaseModel):
         self.max_features = max_features
         self.compression = compression
         self.compression_components = compression_components
+        self.compression_epochs = compression_epochs
+        self.compression_device = compression_device
         self.predict_chunk_rows = predict_chunk_rows
         self.seed = seed
         self._compressor: BasePreprocessor | None = None
@@ -164,7 +177,13 @@ class FoundationModel(BaseModel):
             return feat
         n_components = self.compression_components or self.max_features
         n_components = min(n_components, feat.shape[1] - 1, len(feat))
-        self._compressor = _build_compressor(self.compression, n_components, self.seed)
+        self._compressor = _build_compressor(
+            self.compression,
+            n_components,
+            self.seed,
+            epochs=self.compression_epochs,
+            device=self.compression_device,
+        )
         return self._compressor.fit_transform(feat, y)
 
     def _prepare_predict(self, X: pd.DataFrame) -> pd.DataFrame:
@@ -191,6 +210,8 @@ class TabPFNModel(FoundationModel):
         max_features: int = TABPFN_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        compression_epochs: int = 20,
+        compression_device: str | None = None,
         predict_chunk_rows: int = TABPFN_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN",
@@ -200,6 +221,8 @@ class TabPFNModel(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            compression_epochs=compression_epochs,
+            compression_device=compression_device,
             predict_chunk_rows=predict_chunk_rows,
             seed=seed,
             name=name,
@@ -237,6 +260,8 @@ class TabPFN3Model(FoundationModel):
         max_features: int = TABPFN3_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        compression_epochs: int = 20,
+        compression_device: str | None = None,
         predict_chunk_rows: int = TABPFN3_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN3",
@@ -246,6 +271,8 @@ class TabPFN3Model(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            compression_epochs=compression_epochs,
+            compression_device=compression_device,
             predict_chunk_rows=predict_chunk_rows,
             seed=seed,
             name=name,
@@ -287,6 +314,8 @@ class TabPFN3ReasoningModel(FoundationModel):
         max_features: int = TABPFN3_REASONING_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
+        compression_epochs: int = 20,
+        compression_device: str | None = None,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN3Reasoning",
     ) -> None:
@@ -295,6 +324,8 @@ class TabPFN3ReasoningModel(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            compression_epochs=compression_epochs,
+            compression_device=compression_device,
             seed=seed,
             name=name,
         )
@@ -341,7 +372,9 @@ class TabICLModel(FoundationModel):
         max_features: int = TABICL_MAX_FEATURES,
         compression: str | None = DEFAULT_COMPRESSION,
         compression_components: int | None = None,
-        predict_chunk_rows: int = TABPFN_PREDICT_CHUNK_ROWS,
+        compression_epochs: int = 20,
+        compression_device: str | None = None,
+        predict_chunk_rows: int = TABICL_PREDICT_CHUNK_ROWS,
         seed: int = DEFAULT_SEED,
         name: str | None = "TabICL",
     ) -> None:
@@ -350,6 +383,8 @@ class TabICLModel(FoundationModel):
             max_features=max_features,
             compression=compression,
             compression_components=compression_components,
+            compression_epochs=compression_epochs,
+            compression_device=compression_device,
             predict_chunk_rows=predict_chunk_rows,
             seed=seed,
             name=name,

--- a/src/alphapulse/models/foundation_models.py
+++ b/src/alphapulse/models/foundation_models.py
@@ -1,38 +1,85 @@
+import os
+from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pandas as pd
 
+from ..preprocessors.autoencoder import AutoencoderPreprocessor
+from ..preprocessors.base import BasePreprocessor
+from ..preprocessors.compression import PCAPreprocessor, TruncatedSVDPreprocessor
 from .base import BaseModel, _numeric
 from .sklearn_models import _load_sklearn, _save_sklearn
 
+COMPRESSION_METHODS = ("pca", "svd", "autoencoder")
+DEFAULT_COMPRESSION = "pca"
+DEFAULT_SEED = 42
+PREDICT_CHUNK_ROWS = 50_000
 
-class TabPFNModel(BaseModel):
-    """TabPFN v2 regression via in-context learning.
+TABPFN_MAX_TRAIN_ROWS = 10_000
+TABPFN_MAX_FEATURES = 500
+TABPFN3_MAX_TRAIN_ROWS = 100_000
+TABPFN3_MAX_FEATURES = 2_000
+TABPFN3_REASONING_MAX_TRAIN_ROWS = 10_000
+TABPFN3_REASONING_MAX_FEATURES = 500
+TABICL_MAX_TRAIN_ROWS = 60_000
+TABICL_MAX_FEATURES = 500
 
-    A pre-trained foundation model that learns from context at inference time.
-    No gradient-based training occurs — fit() stores the data and predict()
-    performs in-context learning over it.
 
-    Requires: pip install 'alphapulse[foundation]'
+def _build_compressor(method: str, n_components: int, seed: int) -> BasePreprocessor:
+    if method == "pca":
+        return PCAPreprocessor(n_components=n_components, random_state=seed)
+    if method == "svd":
+        return TruncatedSVDPreprocessor(n_components=n_components, random_state=seed)
+    if method == "autoencoder":
+        return AutoencoderPreprocessor(latent_dim=n_components, seed=seed)
+    raise ValueError(
+        f"Unknown compression method: {method!r}. "
+        f"Expected one of {COMPRESSION_METHODS}."
+    )
 
-    Constraints:
-        - Up to 50 000 training samples and 2 000 features (TabPFN v2).
-        - GPU recommended; CPU feasible only for small datasets (≲1 000 rows).
+
+class FoundationModel(BaseModel):
+    """Base for in-context tabular foundation models (TabPFN/TabICL).
+
+    These models have hard limits on context size, so the wrapper makes them
+    work on Numerai-scale data by (1) randomly subsampling training rows to
+    ``max_train_rows``, (2) compressing features to at most ``max_features``
+    columns via PCA/SVD/autoencoder when the input is wider, and
+    (3) predicting in chunks to bound memory.
     """
 
     def __init__(
         self,
-        n_estimators: int = 8,
-        device: str | None = None,
-        ignore_pretraining_limits: bool = False,
-        name: str | None = "TabPFN",
+        *,
+        max_train_rows: int,
+        max_features: int,
+        compression: str | None = DEFAULT_COMPRESSION,
+        compression_components: int | None = None,
+        seed: int = DEFAULT_SEED,
+        name: str | None = None,
     ) -> None:
         super().__init__(name)
-        self.n_estimators = n_estimators
-        self.device = device
-        self.ignore_pretraining_limits = ignore_pretraining_limits
+        if max_train_rows < 1:
+            raise ValueError(f"max_train_rows must be positive, got {max_train_rows}")
+        if max_features < 1:
+            raise ValueError(f"max_features must be positive, got {max_features}")
+        if compression is not None and compression not in COMPRESSION_METHODS:
+            raise ValueError(
+                f"Unknown compression method: {compression!r}. "
+                f"Expected one of {COMPRESSION_METHODS} or None."
+            )
+        self.max_train_rows = max_train_rows
+        self.max_features = max_features
+        self.compression = compression
+        self.compression_components = compression_components
+        self.seed = seed
+        self._compressor: BasePreprocessor | None = None
+        self._medians: pd.Series | None = None
+
+    @abstractmethod
+    def _make_regressor(self) -> Any: ...
 
     def train(
         self,
@@ -42,44 +89,128 @@ class TabPFNModel(BaseModel):
         y_val: pd.Series | None = None,
         **kwargs: Any,
     ) -> dict[str, float]:
-        from tabpfn import TabPFNRegressor
+        regressor = self._make_regressor()
+        feat, y = self._prepare_train(X_train, y_train)
+        regressor.fit(feat, y)
+        self.model = regressor
+        self.is_trained = True
+        return {}
 
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        self._require_trained()
+        feat = self._prepare_predict(X)
+        chunks = [
+            np.asarray(
+                self.model.predict(feat.iloc[start : start + PREDICT_CHUNK_ROWS]),
+                dtype=np.float64,
+            )
+            for start in range(0, len(feat), PREDICT_CHUNK_ROWS)
+        ]
+        return np.concatenate(chunks) if chunks else np.empty(0, dtype=np.float64)
+
+    def save(self, path: Path) -> None:
+        self._require_trained()
+        payload = {
+            "model": self.model,
+            "compressor": self._compressor,
+            "medians": self._medians,
+        }
+        _save_sklearn(payload, path)
+
+    def load(self, path: Path) -> "FoundationModel":
+        payload = _load_sklearn(path)
+        self.model = payload["model"]
+        self._compressor = payload["compressor"]
+        self._medians = payload["medians"]
+        self.is_trained = True
+        return self
+
+    def _prepare_train(
+        self, X_train: pd.DataFrame, y_train: pd.Series
+    ) -> tuple[pd.DataFrame, pd.Series]:
         feat = _numeric(X_train)
         if feat.shape[1] == 0:
             raise ValueError(f"{self.name}: no numeric feature columns found.")
+        feat, y = self._subsample(feat, y_train)
+        self._medians = feat.median()
+        feat = feat.fillna(self._medians)
+        feat = self._fit_compressor(feat, y)
+        return feat, y
+
+    def _subsample(
+        self, feat: pd.DataFrame, y: pd.Series
+    ) -> tuple[pd.DataFrame, pd.Series]:
+        if len(feat) <= self.max_train_rows:
+            return feat, y
+        rng = np.random.default_rng(self.seed)
+        idx = rng.choice(len(feat), size=self.max_train_rows, replace=False)
+        idx.sort()
+        return feat.iloc[idx], y.iloc[idx]
+
+    def _fit_compressor(self, feat: pd.DataFrame, y: pd.Series) -> pd.DataFrame:
+        if self.compression is None or feat.shape[1] <= self.max_features:
+            self._compressor = None
+            return feat
+        n_components = self.compression_components or self.max_features
+        n_components = min(n_components, feat.shape[1] - 1, len(feat))
+        self._compressor = _build_compressor(self.compression, n_components, self.seed)
+        return self._compressor.fit_transform(feat, y)
+
+    def _prepare_predict(self, X: pd.DataFrame) -> pd.DataFrame:
+        feat = _numeric(X)
+        if self._medians is not None:
+            feat = feat.reindex(columns=self._medians.index).fillna(self._medians)
+        if self._compressor is not None:
+            feat = self._compressor.transform(feat)
+        return feat
+
+
+class TabPFNModel(FoundationModel):
+    """TabPFN v2 regression via in-context learning.
+
+    Requires: pip install 'alphapulse[foundation]'
+    """
+
+    def __init__(
+        self,
+        n_estimators: int = 8,
+        device: str | None = None,
+        ignore_pretraining_limits: bool = False,
+        max_train_rows: int = TABPFN_MAX_TRAIN_ROWS,
+        max_features: int = TABPFN_MAX_FEATURES,
+        compression: str | None = DEFAULT_COMPRESSION,
+        compression_components: int | None = None,
+        seed: int = DEFAULT_SEED,
+        name: str | None = "TabPFN",
+    ) -> None:
+        super().__init__(
+            max_train_rows=max_train_rows,
+            max_features=max_features,
+            compression=compression,
+            compression_components=compression_components,
+            seed=seed,
+            name=name,
+        )
+        self.n_estimators = n_estimators
+        self.device = device
+        self.ignore_pretraining_limits = ignore_pretraining_limits
+
+    def _make_regressor(self) -> Any:
+        from tabpfn import TabPFNRegressor
+
         init_kwargs: dict[str, Any] = {
             "n_estimators": self.n_estimators,
             "ignore_pretraining_limits": self.ignore_pretraining_limits,
         }
         if self.device is not None:
             init_kwargs["device"] = self.device
-        self.model = TabPFNRegressor(**init_kwargs)
-        self.model.fit(feat, y_train)
-        self.is_trained = True
-        return {}
-
-    def predict(self, X: pd.DataFrame) -> np.ndarray:
-        self._require_trained()
-        return np.asarray(self.model.predict(_numeric(X)), dtype=np.float64)
-
-    def save(self, path: Path) -> None:
-        self._require_trained()
-        _save_sklearn(self.model, path)
-
-    def load(self, path: Path) -> "TabPFNModel":
-        self.model = _load_sklearn(path)
-        self.is_trained = True
-        return self
+        return TabPFNRegressor(**init_kwargs)
 
 
-class TabPFN3Model(BaseModel):
+class TabPFN3Model(FoundationModel):
     """TabPFN v3 regression via in-context learning (local OSS).
 
     Requires: pip install 'alphapulse[foundation]'
-
-    Constraints:
-        - Up to ~1M training samples (TabPFN v3).
-        - GPU recommended for large datasets.
     """
 
     def __init__(
@@ -88,29 +219,31 @@ class TabPFN3Model(BaseModel):
         n_estimators: int = 8,
         device: str | None = None,
         ignore_pretraining_limits: bool = False,
-        random_state: int = 42,
+        random_state: int = DEFAULT_SEED,
+        max_train_rows: int = TABPFN3_MAX_TRAIN_ROWS,
+        max_features: int = TABPFN3_MAX_FEATURES,
+        compression: str | None = DEFAULT_COMPRESSION,
+        compression_components: int | None = None,
+        seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN3",
     ) -> None:
-        super().__init__(name)
+        super().__init__(
+            max_train_rows=max_train_rows,
+            max_features=max_features,
+            compression=compression,
+            compression_components=compression_components,
+            seed=seed,
+            name=name,
+        )
         self.model_path = model_path
         self.n_estimators = n_estimators
         self.device = device
         self.ignore_pretraining_limits = ignore_pretraining_limits
         self.random_state = random_state
 
-    def train(
-        self,
-        X_train: pd.DataFrame,
-        y_train: pd.Series,
-        X_val: pd.DataFrame | None = None,
-        y_val: pd.Series | None = None,
-        **kwargs: Any,
-    ) -> dict[str, float]:
+    def _make_regressor(self) -> Any:
         from tabpfn import TabPFNRegressor
 
-        feat = _numeric(X_train)
-        if feat.shape[1] == 0:
-            raise ValueError(f"{self.name}: no numeric feature columns found.")
         init_kwargs: dict[str, Any] = {
             "model_path": self.model_path,
             "n_estimators": self.n_estimators,
@@ -119,31 +252,14 @@ class TabPFN3Model(BaseModel):
         }
         if self.device is not None:
             init_kwargs["device"] = self.device
-        self.model = TabPFNRegressor(**init_kwargs)
-        self.model.fit(feat, y_train)
-        self.is_trained = True
-        return {}
-
-    def predict(self, X: pd.DataFrame) -> np.ndarray:
-        self._require_trained()
-        return np.asarray(self.model.predict(_numeric(X)), dtype=np.float64)
-
-    def save(self, path: Path) -> None:
-        self._require_trained()
-        _save_sklearn(self.model, path)
-
-    def load(self, path: Path) -> "TabPFN3Model":
-        self.model = _load_sklearn(path)
-        self.is_trained = True
-        return self
+        return TabPFNRegressor(**init_kwargs)
 
 
-class TabPFN3ReasoningModel(BaseModel):
+class TabPFN3ReasoningModel(FoundationModel):
     """TabPFN v3 regression via Prior Labs API with reasoning mode.
 
     Requires: pip install 'alphapulse[foundation-api]' and TABPFN_API_KEY.
-
-    Note: fits are API-metered and slower than local TabPFN3Model.
+    Note: fits are API-metered, so the default row budget is conservative.
     """
 
     def __init__(
@@ -152,24 +268,27 @@ class TabPFN3ReasoningModel(BaseModel):
         thinking_effort: str = "medium",
         thinking_timeout_s: int = 300,
         thinking_metric: str = "rmse",
+        max_train_rows: int = TABPFN3_REASONING_MAX_TRAIN_ROWS,
+        max_features: int = TABPFN3_REASONING_MAX_FEATURES,
+        compression: str | None = DEFAULT_COMPRESSION,
+        compression_components: int | None = None,
+        seed: int = DEFAULT_SEED,
         name: str | None = "TabPFN3Reasoning",
     ) -> None:
-        super().__init__(name)
+        super().__init__(
+            max_train_rows=max_train_rows,
+            max_features=max_features,
+            compression=compression,
+            compression_components=compression_components,
+            seed=seed,
+            name=name,
+        )
         self.thinking_mode = thinking_mode
         self.thinking_effort = thinking_effort
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
 
-    def train(
-        self,
-        X_train: pd.DataFrame,
-        y_train: pd.Series,
-        X_val: pd.DataFrame | None = None,
-        y_val: pd.Series | None = None,
-        **kwargs: Any,
-    ) -> dict[str, float]:
-        import os
-
+    def _make_regressor(self) -> Any:
         try:
             from tabpfn_client import TabPFNRegressor
         except ImportError as exc:
@@ -182,41 +301,16 @@ class TabPFN3ReasoningModel(BaseModel):
             raise ValueError(
                 "TabPFN3ReasoningModel requires TABPFN_API_KEY environment variable."
             )
-
-        feat = _numeric(X_train)
-        if feat.shape[1] == 0:
-            raise ValueError(f"{self.name}: no numeric feature columns found.")
-        init_kwargs: dict[str, Any] = {
-            "thinking_mode": self.thinking_mode,
-            "thinking_effort": self.thinking_effort,
-            "thinking_timeout_s": self.thinking_timeout_s,
-            "thinking_metric": self.thinking_metric,
-        }
-        self.model = TabPFNRegressor(**init_kwargs)
-        self.model.fit(feat, y_train)
-        self.is_trained = True
-        return {}
-
-    def predict(self, X: pd.DataFrame) -> np.ndarray:
-        self._require_trained()
-        return np.asarray(self.model.predict(_numeric(X)), dtype=np.float64)
-
-    def save(self, path: Path) -> None:
-        self._require_trained()
-        _save_sklearn(self.model, path)
-
-    def load(self, path: Path) -> "TabPFN3ReasoningModel":
-        self.model = _load_sklearn(path)
-        self.is_trained = True
-        return self
+        return TabPFNRegressor(
+            thinking_mode=self.thinking_mode,
+            thinking_effort=self.thinking_effort,
+            thinking_timeout_s=self.thinking_timeout_s,
+            thinking_metric=self.thinking_metric,
+        )
 
 
-class TabICLModel(BaseModel):
+class TabICLModel(FoundationModel):
     """TabICL v2 regression via in-context learning.
-
-    A pre-trained tabular foundation model that scales to 600 K+ rows via
-    CPU/disk offloading. Like TabPFN, fit() stores the context and learning
-    occurs during predict().
 
     Requires: pip install 'alphapulse[foundation]'
     """
@@ -227,29 +321,31 @@ class TabICLModel(BaseModel):
         device: str | None = None,
         kv_cache: bool = False,
         batch_size: int = 8,
-        random_state: int = 42,
+        random_state: int = DEFAULT_SEED,
+        max_train_rows: int = TABICL_MAX_TRAIN_ROWS,
+        max_features: int = TABICL_MAX_FEATURES,
+        compression: str | None = DEFAULT_COMPRESSION,
+        compression_components: int | None = None,
+        seed: int = DEFAULT_SEED,
         name: str | None = "TabICL",
     ) -> None:
-        super().__init__(name)
+        super().__init__(
+            max_train_rows=max_train_rows,
+            max_features=max_features,
+            compression=compression,
+            compression_components=compression_components,
+            seed=seed,
+            name=name,
+        )
         self.n_estimators = n_estimators
         self.device = device
         self.kv_cache = kv_cache
         self.batch_size = batch_size
         self.random_state = random_state
 
-    def train(
-        self,
-        X_train: pd.DataFrame,
-        y_train: pd.Series,
-        X_val: pd.DataFrame | None = None,
-        y_val: pd.Series | None = None,
-        **kwargs: Any,
-    ) -> dict[str, float]:
+    def _make_regressor(self) -> Any:
         from tabicl import TabICLRegressor
 
-        feat = _numeric(X_train)
-        if feat.shape[1] == 0:
-            raise ValueError(f"{self.name}: no numeric feature columns found.")
         init_kwargs: dict[str, Any] = {
             "n_estimators": self.n_estimators,
             "kv_cache": self.kv_cache,
@@ -258,20 +354,4 @@ class TabICLModel(BaseModel):
         }
         if self.device is not None:
             init_kwargs["device"] = self.device
-        self.model = TabICLRegressor(**init_kwargs)
-        self.model.fit(feat, y_train)
-        self.is_trained = True
-        return {}
-
-    def predict(self, X: pd.DataFrame) -> np.ndarray:
-        self._require_trained()
-        return np.asarray(self.model.predict(_numeric(X)), dtype=np.float64)
-
-    def save(self, path: Path) -> None:
-        self._require_trained()
-        _save_sklearn(self.model, path)
-
-    def load(self, path: Path) -> "TabICLModel":
-        self.model = _load_sklearn(path)
-        self.is_trained = True
-        return self
+        return TabICLRegressor(**init_kwargs)

--- a/src/alphapulse/models/xgboost_model.py
+++ b/src/alphapulse/models/xgboost_model.py
@@ -15,19 +15,38 @@ def _make_ray_callbacks() -> list[Any]:
         if ray_session.get_session() is None:
             return []
 
-        def _report_cb(env: Any) -> None:
-            eval_rmse: float | None = None
-            for item in getattr(env, "evaluation_result_list", []) or []:
-                if not isinstance(item, tuple) or len(item) < 3:
-                    continue
-                dataset, metric_name, value = item[0], item[1], item[2]
-                if dataset == "eval" and metric_name == "rmse":
-                    eval_rmse = float(value)
-                    break
-            if eval_rmse is not None:
-                ray_session.report({"eval_rmse": eval_rmse})
+        class _RayReportCallback(xgb.callback.TrainingCallback):
+            def after_iteration(
+                self,
+                model: Any,
+                _epoch: int,
+                evals_log: dict[
+                    str, dict[str, list[float] | list[tuple[float, float]]]
+                ],
+            ) -> bool:
+                eval_rmse: float | None = None
+                for dataset, metrics in (evals_log or {}).items():
+                    if dataset == "eval" and "rmse" in metrics:
+                        values = metrics["rmse"]
+                        if values:
+                            last = values[-1]
+                            eval_rmse = float(
+                                last[0] if isinstance(last, tuple) else last
+                            )
+                            break
+                if eval_rmse is None:
+                    for item in getattr(model, "evaluation_result_list", []) or []:
+                        if not isinstance(item, tuple) or len(item) < 3:
+                            continue
+                        dataset, metric_name, value = item[0], item[1], item[2]
+                        if dataset == "eval" and metric_name == "rmse":
+                            eval_rmse = float(value)
+                            break
+                if eval_rmse is not None:
+                    ray_session.report({"eval_rmse": eval_rmse})
+                return False
 
-        return [_report_cb]
+        return [_RayReportCallback()]
     except ImportError:
         return []
 

--- a/src/alphapulse/pipeline/multihead.py
+++ b/src/alphapulse/pipeline/multihead.py
@@ -196,11 +196,12 @@ class MultiHeadPipeline:
             if X_g.isna().any().any():
                 post_nan_mask = ~X_g.isna().any(axis=1)
                 X_g = X_g[post_nan_mask]
-                combined_valid_mask = valid_mask.copy()
-                valid_indices = np.where(valid_mask)[0]
-                combined_valid_mask[valid_indices[~post_nan_mask]] = False
+                combined_valid_mask = valid_mask.to_numpy(dtype=bool).copy()
+                valid_positions = np.flatnonzero(combined_valid_mask)
+                post_arr = np.asarray(post_nan_mask, dtype=bool)
+                combined_valid_mask[valid_positions[~post_arr]] = False
             else:
-                combined_valid_mask = valid_mask
+                combined_valid_mask = valid_mask.to_numpy(dtype=bool)
 
             if len(X_g) == 0:
                 return np.full(len(X), 0.0)
@@ -245,7 +246,7 @@ class MultiHeadPipeline:
                 valid_preds = self._ensemble.combine(preds)
 
             raw_preds = np.full(len(X), safe_median(valid_preds))
-            raw_preds[nan_mask] = valid_preds
+            raw_preds[nan_mask.to_numpy(dtype=bool)] = valid_preds
             return raw_preds
 
         if len(self.heads) == 1:

--- a/src/alphapulse/pipeline/pipeline.py
+++ b/src/alphapulse/pipeline/pipeline.py
@@ -8,6 +8,7 @@ import pandas as pd
 from ..evaluation.metrics import rank_normalize
 from ..models.base import BaseModel
 from ..preprocessors.base import BasePreprocessor, TrainEvalPreprocessor
+from ..preprocessors.era_stable import EraStableFeatureSelector
 from .ensemble import EnsembleStrategy
 from .neutralizer import FeatureNeutralizer
 from .row_utils import (
@@ -119,7 +120,10 @@ class Pipeline:
         for pp in self.preprocessors:
             if isinstance(pp, TrainEvalPreprocessor):
                 pp.train()
-            pp.fit(X_fit, y)
+            if isinstance(pp, EraStableFeatureSelector) and era_meta is not None:
+                pp.fit(X_fit, y, eras=era_meta["era"])
+            else:
+                pp.fit(X_fit, y)
             X_fit = pp.transform(X_fit)
             X_fit = reattach_protected_columns(X_fit, era_meta)
 
@@ -238,14 +242,21 @@ class Pipeline:
         else:
             raw_preds = np.full(len(X), safe_median(valid_preds))
             if valid_mask is not None and post_nan_mask is not None:
-                combined = valid_mask.copy()
-                valid_indices = np.where(valid_mask)[0]
-                combined[valid_indices[~post_nan_mask]] = False
+                combined = valid_mask.to_numpy(dtype=bool).copy()
+                valid_positions = np.flatnonzero(combined)
+                post_arr = np.asarray(post_nan_mask, dtype=bool)
+                combined[valid_positions[~post_arr]] = False
                 raw_preds[combined] = valid_preds
             elif valid_mask is not None:
-                raw_preds[valid_mask] = valid_preds
+                raw_preds[valid_mask.to_numpy(dtype=bool)] = valid_preds
             else:
-                raw_preds[post_nan_mask] = valid_preds
+                assert post_nan_mask is not None
+                post_arr = (
+                    post_nan_mask.to_numpy(dtype=bool)
+                    if hasattr(post_nan_mask, "to_numpy")
+                    else np.asarray(post_nan_mask, dtype=bool)
+                )
+                raw_preds[post_arr] = valid_preds
 
         if self._neutralizer is None:
             return raw_preds

--- a/src/alphapulse/preprocessors/__init__.py
+++ b/src/alphapulse/preprocessors/__init__.py
@@ -1,3 +1,4 @@
+from .autoencoder import AutoencoderPreprocessor
 from .base import BasePreprocessor, TrainEvalPreprocessor
 from .compression import PCAPreprocessor, TruncatedSVDPreprocessor
 from .era_stable import EraStableFeatureSelector
@@ -9,6 +10,7 @@ from .packboost import PackboostPreprocessor
 from .scaling import RobustScalerPreprocessor, StandardScalerPreprocessor
 
 __all__ = [
+    "AutoencoderPreprocessor",
     "BasePreprocessor",
     "EraStableFeatureSelector",
     "GaussianNoiseInjector",

--- a/src/alphapulse/preprocessors/autoencoder.py
+++ b/src/alphapulse/preprocessors/autoencoder.py
@@ -1,0 +1,138 @@
+from typing import Any, Self
+
+import numpy as np
+import pandas as pd
+
+from .base import BasePreprocessor
+
+DEFAULT_LATENT_DIM = 64
+DEFAULT_HIDDEN_DIM = 256
+DEFAULT_EPOCHS = 20
+DEFAULT_BATCH_SIZE = 1024
+DEFAULT_LEARNING_RATE = 1e-3
+DEFAULT_SEED = 42
+_STD_EPS = 1e-8
+
+
+def _require_torch() -> Any:
+    try:
+        import torch
+    except ImportError as exc:
+        raise ImportError(
+            "AutoencoderPreprocessor requires torch. "
+            "Install with: pip install 'alphapulse[deep]'"
+        ) from exc
+    return torch
+
+
+class AutoencoderPreprocessor(BasePreprocessor):
+    _medians: pd.Series
+    _mean: np.ndarray
+    _std: np.ndarray
+    _encoder: Any
+    _device: Any
+
+    def __init__(
+        self,
+        latent_dim: int = DEFAULT_LATENT_DIM,
+        hidden_dim: int = DEFAULT_HIDDEN_DIM,
+        epochs: int = DEFAULT_EPOCHS,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        learning_rate: float = DEFAULT_LEARNING_RATE,
+        device: str | None = None,
+        seed: int = DEFAULT_SEED,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name)
+        if latent_dim < 1:
+            raise ValueError(f"latent_dim must be positive, got {latent_dim}")
+        if epochs < 1:
+            raise ValueError(f"epochs must be positive, got {epochs}")
+        self.latent_dim = latent_dim
+        self.hidden_dim = hidden_dim
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.learning_rate = learning_rate
+        self.device = device
+        self.seed = seed
+        self._numeric_cols: list[str] = []
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None = None) -> Self:
+        torch = _require_torch()
+        self._numeric_cols = list(X.select_dtypes(include=[np.number]).columns)
+        if not self._numeric_cols:
+            raise ValueError("AutoencoderPreprocessor: no numeric columns found.")
+        if self.latent_dim >= len(self._numeric_cols):
+            raise ValueError(
+                f"latent_dim ({self.latent_dim}) must be smaller than the number "
+                f"of numeric columns ({len(self._numeric_cols)})."
+            )
+
+        values = X[self._numeric_cols].astype(np.float64)
+        self._medians = values.median()
+        arr = values.fillna(self._medians).to_numpy(dtype=np.float32)
+        self._mean = arr.mean(axis=0)
+        self._std = arr.std(axis=0) + _STD_EPS
+        arr = (arr - self._mean) / self._std
+
+        torch.manual_seed(self.seed)
+        self._device = self._resolve_device(torch)
+        encoder, model = self._build_model(torch, arr.shape[1])
+        self._train_model(torch, model, arr)
+        encoder.eval()
+        self._encoder = encoder
+        self.is_fitted = True
+        return self
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        if not self.is_fitted:
+            raise ValueError("Preprocessor not fitted!")
+        torch = _require_torch()
+        values = X[self._numeric_cols].astype(np.float64).fillna(self._medians)
+        arr = (values.to_numpy(dtype=np.float32) - self._mean) / self._std
+        outputs: list[np.ndarray] = []
+        with torch.no_grad():
+            for start in range(0, len(arr), self.batch_size):
+                batch = torch.from_numpy(arr[start : start + self.batch_size])
+                outputs.append(self._encoder(batch.to(self._device)).cpu().numpy())
+        out = (
+            np.concatenate(outputs)
+            if outputs
+            else np.empty((0, self.latent_dim), dtype=np.float32)
+        )
+        cols = [f"ae_{i}" for i in range(self.latent_dim)]
+        return pd.DataFrame(out.astype(np.float64), columns=cols, index=X.index)
+
+    def _resolve_device(self, torch: Any) -> Any:
+        if self.device is not None:
+            return torch.device(self.device)
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def _build_model(self, torch: Any, n_features: int) -> tuple[Any, Any]:
+        encoder = torch.nn.Sequential(
+            torch.nn.Linear(n_features, self.hidden_dim),
+            torch.nn.ReLU(),
+            torch.nn.Linear(self.hidden_dim, self.latent_dim),
+        )
+        decoder = torch.nn.Sequential(
+            torch.nn.Linear(self.latent_dim, self.hidden_dim),
+            torch.nn.ReLU(),
+            torch.nn.Linear(self.hidden_dim, n_features),
+        )
+        model = torch.nn.Sequential(encoder, decoder).to(self._device)
+        return encoder, model
+
+    def _train_model(self, torch: Any, model: Any, arr: np.ndarray) -> None:
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.learning_rate)
+        loss_fn = torch.nn.MSELoss()
+        data = torch.from_numpy(arr)
+        rng = np.random.default_rng(self.seed)
+        model.train()
+        for _ in range(self.epochs):
+            order = rng.permutation(len(arr))
+            for start in range(0, len(arr), self.batch_size):
+                batch = data[order[start : start + self.batch_size]].to(self._device)
+                optimizer.zero_grad()
+                loss = loss_fn(model(batch), batch)
+                loss.backward()
+                optimizer.step()

--- a/src/alphapulse/preprocessors/era_stable.py
+++ b/src/alphapulse/preprocessors/era_stable.py
@@ -3,8 +3,8 @@ from typing import Self
 import numpy as np
 import pandas as pd
 
-from ..constants import _PROTECTED_COLS
 from .base import BasePreprocessor
+from .feature_selection import _numeric_feature_cols
 
 _MIN_ERAS_REQUIRED = 2
 
@@ -72,17 +72,17 @@ class EraStableFeatureSelector(BasePreprocessor):
     ) -> Self:
         if y is None:
             raise ValueError("EraStableFeatureSelector requires y for fit().")
-        if eras is None and "era" in X.columns:
-            eras = X["era"]
 
         import lightgbm as lgb
 
-        feature_cols = [c for c in X.columns if c not in _PROTECTED_COLS]
+        feature_cols = _numeric_feature_cols(X)
+        if not feature_cols:
+            raise ValueError("EraStableFeatureSelector: no numeric columns found.")
+        X_num = X[feature_cols]
         n_features = len(feature_cols)
         n_keep = max(1, int(n_features * self.keep_fraction))
 
         if eras is None or len(pd.unique(eras)) < _MIN_ERAS_REQUIRED:
-            # No era info — fall back to single global importance
             model = lgb.LGBMRegressor(
                 n_estimators=self.n_estimators,
                 max_depth=4,
@@ -91,7 +91,7 @@ class EraStableFeatureSelector(BasePreprocessor):
                 verbosity=-1,
                 n_jobs=1,
             )
-            model.fit(X[feature_cols], y)
+            model.fit(X_num, y)
             importances = np.asarray(model.feature_importances_, dtype=np.float64)
             ranked = np.argsort(importances)[::-1][:n_keep]
             self.selected_columns_ = [str(feature_cols[i]) for i in ranked]
@@ -114,7 +114,7 @@ class EraStableFeatureSelector(BasePreprocessor):
         era_importances: list[np.ndarray] = []
         for era in unique_eras:
             mask = era_arr == era
-            X_era = X[mask][feature_cols]
+            X_era = X_num[mask]
             y_era = y[mask]
             if len(X_era) < 20:
                 continue
@@ -146,7 +146,7 @@ class EraStableFeatureSelector(BasePreprocessor):
                 verbosity=-1,
                 n_jobs=1,
             )
-            model.fit(X[feature_cols], y)
+            model.fit(X_num, y)
             importances = np.asarray(model.feature_importances_, dtype=np.float64)
             ranked = np.argsort(importances)[::-1][:n_keep]
             self.selected_columns_ = [str(feature_cols[i]) for i in ranked]

--- a/src/alphapulse/preprocessors/feature_selection.py
+++ b/src/alphapulse/preprocessors/feature_selection.py
@@ -3,8 +3,11 @@ from typing import Self
 import numpy as np
 import pandas as pd
 
-from ..constants import _PROTECTED_COLS
 from .base import BasePreprocessor
+
+
+def _numeric_feature_cols(X: pd.DataFrame) -> list[str]:
+    return list(X.select_dtypes(include=[np.number]).columns)
 
 
 class VarianceFeatureSelector(BasePreprocessor):
@@ -24,19 +27,22 @@ class VarianceFeatureSelector(BasePreprocessor):
         self.selected_columns_: list[str] = []
 
     def fit(self, X: pd.DataFrame, y: pd.Series | None = None) -> Self:
-        feat_cols = [c for c in X.columns if c not in _PROTECTED_COLS]
-        variances = X[feat_cols].var(axis=0)
+        feature_cols = _numeric_feature_cols(X)
+        if not feature_cols:
+            raise ValueError("VarianceFeatureSelector: no numeric columns found.")
+        X_num = X[feature_cols]
+        variances = X_num.var(axis=0)
 
         if self.mode == "threshold":
             mask = variances > self.threshold
-            self.selected_columns_ = list(variances.index[mask])
+            self.selected_columns_ = list(X_num.columns[mask])
         else:
-            n_keep = max(1, int(len(feat_cols) * self.keep_fraction))
+            n_keep = max(1, int(len(feature_cols) * self.keep_fraction))
             ranked = variances.sort_values(ascending=False)
             self.selected_columns_ = list(ranked.index[:n_keep])
 
         if not self.selected_columns_:
-            self.selected_columns_ = list(X.columns[:1])
+            self.selected_columns_ = list(feature_cols[:1])
 
         self.is_fitted = True
         return self
@@ -73,9 +79,13 @@ class LGBMImportanceSelector(BasePreprocessor):
         if y is None:
             raise ValueError("LGBMImportanceSelector requires y for fit().")
 
+        feature_cols = _numeric_feature_cols(X)
+        if not feature_cols:
+            raise ValueError("LGBMImportanceSelector: no numeric columns found.")
+        X_num = X[feature_cols]
+
         import lightgbm as lgb
 
-        feat_X = X[[c for c in X.columns if c not in _PROTECTED_COLS]]
         model = lgb.LGBMRegressor(
             n_estimators=self.n_estimators,
             max_depth=self.max_depth,
@@ -84,14 +94,14 @@ class LGBMImportanceSelector(BasePreprocessor):
             verbosity=-1,
             n_jobs=1,
         )
-        model.fit(feat_X, y)
+        model.fit(X_num, y)
 
         importances = np.asarray(model.feature_importances_, dtype=np.float64)
         self.importances_ = importances
 
-        n_keep = max(1, int(len(feat_X.columns) * self.keep_fraction))
+        n_keep = max(1, int(len(feature_cols) * self.keep_fraction))
         top_indices = np.argsort(importances)[::-1][:n_keep]
-        self.selected_columns_ = [str(feat_X.columns[i]) for i in top_indices]
+        self.selected_columns_ = [str(feature_cols[i]) for i in top_indices]
 
         self.is_fitted = True
         return self

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -52,6 +52,28 @@ class TestMutations:
         with pytest.raises(ValueError, match="proportion"):
             mutations.set_neutralization(_base_config(), 1.5)
 
+    def test_tune_model_params_updates_nested_xgb_params(self) -> None:
+        cfg = {
+            "preprocessors": [],
+            "models": [
+                {
+                    "type": "XGBoost",
+                    "params": {
+                        "params": {
+                            "max_depth": 3,
+                            "learning_rate": 0.01,
+                        }
+                    },
+                }
+            ],
+            "ensemble_method": "single",
+            "ensemble_params": {},
+        }
+        updated = mutations.tune_model_params(cfg, 0, {"max_depth": 7})
+        inner = updated["models"][0]["params"]["params"]
+        assert inner["max_depth"] == 7
+        assert inner["learning_rate"] == 0.01
+
 
 class TestResearchState:
     def test_save_load_roundtrip(self, tmp_path: Any) -> None:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -388,6 +388,17 @@ class TestTrialDB:
                 db.insert_trial(0, {"lr": 0.9})
                 rows = db.load_all_trials()
             assert len(rows) == 1
+            assert rows[0]["flat_config"]["lr"] == pytest.approx(0.9)
+
+    def test_insert_skips_completed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trials.db"
+            with TrialDB(db_path) as db:
+                db.insert_trial(0, {"lr": 0.1})
+                db.update_trial(0, status="completed")
+                db.insert_trial(0, {"lr": 0.9})
+                rows = db.load_all_trials()
+            assert len(rows) == 1
             assert rows[0]["flat_config"]["lr"] == pytest.approx(0.1)
 
     def test_persists_across_connections(self) -> None:

--- a/tests/test_foundation_models.py
+++ b/tests/test_foundation_models.py
@@ -1,8 +1,11 @@
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from alphapulse.hpo.builder import TREE_MODEL_NAMES, build_models
+from alphapulse.models import foundation_models
 from alphapulse.models.foundation_models import (
     TabICLModel,
     TabPFN3Model,
@@ -12,6 +15,7 @@ from alphapulse.models.foundation_models import (
 
 N_ROWS = 50
 N_FEATURES = 4
+N_WIDE_FEATURES = 12
 
 
 @pytest.fixture
@@ -20,6 +24,191 @@ def toy_data() -> tuple[pd.DataFrame, pd.Series]:
     X = pd.DataFrame(rng.standard_normal((N_ROWS, N_FEATURES)), columns=list("ABCD"))
     y = pd.Series(rng.standard_normal(N_ROWS))
     return X, y
+
+
+@pytest.fixture
+def wide_data() -> tuple[pd.DataFrame, pd.Series]:
+    rng = np.random.default_rng(1)
+    X = pd.DataFrame(
+        rng.standard_normal((N_ROWS, N_WIDE_FEATURES)),
+        columns=[f"f{i}" for i in range(N_WIDE_FEATURES)],
+    )
+    y = pd.Series(rng.standard_normal(N_ROWS))
+    return X, y
+
+
+class FakeRegressor:
+    def __init__(self) -> None:
+        self.fit_X: pd.DataFrame | None = None
+        self.fit_y: pd.Series | None = None
+        self.predict_calls: list[pd.DataFrame] = []
+
+    def fit(self, X: pd.DataFrame, y: pd.Series) -> None:
+        self.fit_X = X
+        self.fit_y = y
+
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        self.predict_calls.append(X)
+        return np.zeros(len(X))
+
+
+def _faked(model: TabPFNModel) -> tuple[TabPFNModel, FakeRegressor]:
+    fake = FakeRegressor()
+    model._make_regressor = lambda: fake  # type: ignore[method-assign]
+    return model, fake
+
+
+# ---------------------------------------------------------------------------
+# FoundationModel scaling behavior (mocked regressor)
+# ---------------------------------------------------------------------------
+
+
+def test_train_subsamples_rows_to_cap(toy_data: tuple[pd.DataFrame, pd.Series]) -> None:
+    X, y = toy_data
+    model, fake = _faked(TabPFNModel(max_train_rows=20))
+    model.train(X, y)
+    assert fake.fit_X is not None and fake.fit_y is not None
+    assert len(fake.fit_X) == 20
+    assert len(fake.fit_y) == 20
+
+
+def test_train_keeps_all_rows_under_cap(
+    toy_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = toy_data
+    model, fake = _faked(TabPFNModel(max_train_rows=1000))
+    model.train(X, y)
+    assert fake.fit_X is not None
+    assert len(fake.fit_X) == N_ROWS
+
+
+def test_subsampling_is_deterministic(
+    toy_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = toy_data
+    model_a, fake_a = _faked(TabPFNModel(max_train_rows=20, seed=7))
+    model_b, fake_b = _faked(TabPFNModel(max_train_rows=20, seed=7))
+    model_a.train(X, y)
+    model_b.train(X, y)
+    assert fake_a.fit_X is not None and fake_b.fit_X is not None
+    pd.testing.assert_frame_equal(fake_a.fit_X, fake_b.fit_X)
+
+
+def test_compression_applied_when_too_wide(
+    wide_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = wide_data
+    model, fake = _faked(TabPFNModel(max_features=4, compression="pca"))
+    model.train(X, y)
+    assert fake.fit_X is not None
+    assert fake.fit_X.shape[1] == 4
+    assert all(c.startswith("pca_") for c in fake.fit_X.columns)
+
+
+def test_compression_applied_at_predict(
+    wide_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = wide_data
+    model, fake = _faked(TabPFNModel(max_features=4, compression="svd"))
+    model.train(X, y)
+    preds = model.predict(X)
+    assert preds.shape == (N_ROWS,)
+    assert fake.predict_calls[0].shape[1] == 4
+
+
+def test_compression_skipped_when_narrow(
+    toy_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = toy_data
+    model, fake = _faked(TabPFNModel(max_features=500))
+    model.train(X, y)
+    assert fake.fit_X is not None
+    assert list(fake.fit_X.columns) == list(X.columns)
+
+
+def test_compression_disabled_with_none(
+    wide_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = wide_data
+    model, fake = _faked(TabPFNModel(max_features=4, compression=None))
+    model.train(X, y)
+    assert fake.fit_X is not None
+    assert fake.fit_X.shape[1] == N_WIDE_FEATURES
+
+
+def test_compression_components_override(
+    wide_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = wide_data
+    model, fake = _faked(
+        TabPFNModel(max_features=4, compression="pca", compression_components=2)
+    )
+    model.train(X, y)
+    assert fake.fit_X is not None
+    assert fake.fit_X.shape[1] == 2
+
+
+def test_train_imputes_nans_before_compression(
+    wide_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = wide_data
+    X = X.copy()
+    X.iloc[0, 0] = np.nan
+    model, fake = _faked(TabPFNModel(max_features=4, compression="pca"))
+    model.train(X, y)
+    preds = model.predict(X)
+    assert fake.fit_X is not None
+    assert not fake.fit_X.isna().any().any()
+    assert np.isfinite(preds).all()
+
+
+def test_predict_is_chunked(
+    toy_data: tuple[pd.DataFrame, pd.Series],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    X, y = toy_data
+    monkeypatch.setattr(foundation_models, "PREDICT_CHUNK_ROWS", 20)
+    model, fake = _faked(TabPFNModel())
+    model.train(X, y)
+    preds = model.predict(X)
+    assert preds.shape == (N_ROWS,)
+    assert len(fake.predict_calls) == 3
+
+
+def test_invalid_compression_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown compression method"):
+        TabPFNModel(compression="vae")
+
+
+def test_invalid_max_train_rows_raises() -> None:
+    with pytest.raises(ValueError, match="max_train_rows"):
+        TabPFNModel(max_train_rows=0)
+
+
+def test_save_load_roundtrip_keeps_compressor(
+    wide_data: tuple[pd.DataFrame, pd.Series],
+    tmp_path: Path,
+) -> None:
+    X, y = wide_data
+    model, _ = _faked(TabPFNModel(max_features=4, compression="pca"))
+    model.train(X, y)
+    path = tmp_path / "model.pkl"
+    model.save(path)
+    loaded = TabPFNModel().load(path)
+    preds = loaded.predict(X)
+    assert preds.shape == (N_ROWS,)
+
+
+def test_build_models_passes_scaling_params() -> None:
+    spec = {
+        "type": "TabPFN",
+        "params": {"max_train_rows": 123, "compression": "svd"},
+    }
+    models = build_models([spec])
+    model = models[0]
+    assert isinstance(model, TabPFNModel)
+    assert model.max_train_rows == 123
+    assert model.compression == "svd"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_foundation_models.py
+++ b/tests/test_foundation_models.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 from alphapulse.hpo.builder import TREE_MODEL_NAMES, build_models
-from alphapulse.models import foundation_models
 from alphapulse.models.foundation_models import (
     TabICLModel,
     TabPFN3Model,
@@ -164,11 +163,9 @@ def test_train_imputes_nans_before_compression(
 
 def test_predict_is_chunked(
     toy_data: tuple[pd.DataFrame, pd.Series],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     X, y = toy_data
-    monkeypatch.setattr(foundation_models, "PREDICT_CHUNK_ROWS", 20)
-    model, fake = _faked(TabPFNModel())
+    model, fake = _faked(TabPFNModel(predict_chunk_rows=20))
     model.train(X, y)
     preds = model.predict(X)
     assert preds.shape == (N_ROWS,)

--- a/tests/test_hpo_pipeline.py
+++ b/tests/test_hpo_pipeline.py
@@ -65,6 +65,23 @@ def test_run_trial_returns_metrics(
     assert "max_drawdown" in metrics
 
 
+def test_run_trial_fast_holdout(
+    toy_data_with_era: dict[str, Any], minimal_flat_config: dict[str, Any]
+) -> None:
+    fast_config = {**minimal_flat_config, "hpo_fast": True}
+    metrics = run_trial(fast_config, **toy_data_with_era)
+    assert isinstance(metrics, dict)
+    assert "corr_sharpe" in metrics
+
+
+def test_sample_random_config_fast_tighter_bounds() -> None:
+    config = sample_random_config(seed=42, fast=True)
+    assert config.get("hpo_fast") is True
+    assert config["n_subs"] <= 5
+    assert config["xgb_n_rounds"] <= 400
+    assert config["num_models"] <= 2
+
+
 def test_sample_random_config_returns_dict() -> None:
     config = sample_random_config(seed=42)
     assert isinstance(config, dict)

--- a/tests/test_hpo_pipeline.py
+++ b/tests/test_hpo_pipeline.py
@@ -80,6 +80,87 @@ def test_sample_random_config_fast_tighter_bounds() -> None:
     assert config["n_subs"] <= 5
     assert config["xgb_n_rounds"] <= 400
     assert config["num_models"] <= 2
+    assert "SyntheticDataAugmenter" not in (
+        config.get("model_1_type"),
+        config.get("model_2_type"),
+        config.get("model_3_type"),
+    )
+
+
+def test_resolve_flat_config_fast_foundation_uses_autoencoder() -> None:
+    from alphapulse.hpo.search_space import resolve_flat_config
+
+    flat = {
+        "hpo_fast": True,
+        "num_models": 1,
+        "model_1_type": "TabPFN",
+        "foundation_max_train_rows": 5000,
+        "foundation_n_components": 128,
+        "foundation_n_estimators": 2,
+        "foundation_compression_epochs": 5,
+        "scaler_type": "StandardScaler",
+        "use_packboost": False,
+        "ensemble_method": "single",
+    }
+    cfg = resolve_flat_config(flat)
+    params = cfg["models"][0]["params"]
+    assert params["compression"] == "autoencoder"
+    assert params["n_estimators"] == 2
+    assert params["compression_epochs"] == 5
+    assert cfg["neutralize_proportion"] == 0.0
+
+
+def test_resolve_flat_config_boosting_uses_neutralization() -> None:
+    from alphapulse.hpo.search_space import (
+        MIN_NEUTRALIZATION_PROPORTION,
+        resolve_flat_config,
+    )
+
+    flat = {
+        "num_models": 1,
+        "model_1_type": "XGBoost",
+        "use_neutralization": False,
+        "neutralization_proportion": 0.05,
+        "scaler_type": "StandardScaler",
+        "use_packboost": False,
+        "ensemble_method": "single",
+    }
+    cfg = resolve_flat_config(flat)
+    assert cfg["neutralize_proportion"] >= MIN_NEUTRALIZATION_PROPORTION
+
+
+def test_sample_random_config_boosting_enables_neutralization() -> None:
+    for seed in range(20):
+        config = sample_random_config(seed=seed, fast=True)
+        types = [
+            config.get("model_1_type"),
+            config.get("model_2_type"),
+            config.get("model_3_type"),
+        ][: config["num_models"]]
+        if "TabPFN" in types or "TabICL" in types:
+            assert config["neutralization_proportion"] == 0.0
+            assert config["use_neutralization"] is False
+        else:
+            assert config["use_neutralization"] is True
+            assert config["neutralization_proportion"] >= 0.15
+
+
+def test_resolve_flat_config_skips_augmenter_model_type() -> None:
+    from alphapulse.hpo.search_space import resolve_flat_config
+
+    flat = {
+        "num_models": 2,
+        "model_1_type": "SyntheticDataAugmenter",
+        "model_2_type": "XGBoost",
+        "scaler_type": "StandardScaler",
+        "use_packboost": False,
+        "ensemble_method": "single",
+        "xgb_n_rounds": 100,
+        "xgb_early_stopping": 10,
+    }
+    cfg = resolve_flat_config(flat)
+    assert len(cfg["models"]) == 1
+    assert cfg["models"][0]["type"] == "XGBoost"
 
 
 def test_sample_random_config_returns_dict() -> None:
@@ -101,6 +182,45 @@ def test_lightgbm_uses_lgbm_rounds() -> None:
     kw = get_train_kwargs_from_flat(flat)
     assert kw["n_rounds"] == 777
     assert kw["early_stopping_rounds"] == 33
+
+
+def test_augmentation_aligns_xy_index() -> None:
+    from alphapulse.hpo.objective import _apply_synthetic_augmentation, _fit_pipeline
+    from alphapulse.hpo.search_space import (
+        get_train_kwargs_from_flat,
+        resolve_flat_config,
+    )
+
+    rng = np.random.default_rng(7)
+    rows = 2000
+    X = pd.DataFrame(
+        rng.standard_normal((rows, 12)), columns=[f"f{i}" for i in range(12)]
+    )
+    X.index = rng.integers(1_000_000, 9_000_000, size=rows)
+    X["era"] = np.repeat([f"era_{i:04d}" for i in range(80)], rows // 80)
+    y = pd.Series(rng.standard_normal(rows), index=X.index, name="target")
+    feature_cols = [f"f{i}" for i in range(12)]
+    flat = {
+        "num_models": 1,
+        "model_1_type": "XGBoost",
+        "use_augmentation": True,
+        "augmenter_top_fraction": 0.1,
+        "augmenter_n_synthetic": 200,
+        "scaler_type": "StandardScaler",
+        "use_packboost": False,
+        "ensemble_method": "single",
+        "n_subs": 3,
+        "xgb_max_depth": 3,
+        "xgb_learning_rate": 0.05,
+        "xgb_n_rounds": 20,
+        "xgb_early_stopping": 5,
+    }
+    X_aug, y_aug = _apply_synthetic_augmentation(X, y, flat, feature_cols, seed=7)
+    assert X_aug.index.equals(y_aug.index)
+    assert len(X_aug) == len(y_aug)
+    cfg = resolve_flat_config(flat)
+    kw = get_train_kwargs_from_flat(flat)
+    _fit_pipeline(cfg, feature_cols, X, y, kw, flat_config=flat, seed=7)
 
 
 def test_xgb_defaults_when_type_xgb() -> None:

--- a/tests/test_hpo_pipeline.py
+++ b/tests/test_hpo_pipeline.py
@@ -88,7 +88,18 @@ def test_sample_random_config_fast_tighter_bounds() -> None:
 
 
 def test_resolve_flat_config_fast_foundation_uses_autoencoder() -> None:
-    from alphapulse.hpo.search_space import resolve_flat_config
+    from alphapulse.hpo.search_space import (
+        _torch_available,
+        resolve_flat_config,
+        resolve_foundation_compression,
+    )
+
+    assert resolve_foundation_compression(None, hpo_fast=True) in {
+        "autoencoder",
+        "pca",
+    }
+    if not _torch_available():
+        assert resolve_foundation_compression("autoencoder") == "pca"
 
     flat = {
         "hpo_fast": True,
@@ -104,13 +115,14 @@ def test_resolve_flat_config_fast_foundation_uses_autoencoder() -> None:
     }
     cfg = resolve_flat_config(flat)
     params = cfg["models"][0]["params"]
-    assert params["compression"] == "autoencoder"
+    expected = "autoencoder" if _torch_available() else "pca"
+    assert params["compression"] == expected
     assert params["n_estimators"] == 2
     assert params["compression_epochs"] == 5
     assert cfg["neutralize_proportion"] == 0.0
 
 
-def test_resolve_flat_config_boosting_uses_neutralization() -> None:
+def test_resolve_flat_config_boosting_respects_neutralization_flag() -> None:
     from alphapulse.hpo.search_space import (
         MIN_NEUTRALIZATION_PROPORTION,
         resolve_flat_config,
@@ -126,10 +138,35 @@ def test_resolve_flat_config_boosting_uses_neutralization() -> None:
         "ensemble_method": "single",
     }
     cfg = resolve_flat_config(flat)
+    assert cfg["neutralize_proportion"] == 0.0
+
+    flat["use_neutralization"] = True
+    cfg = resolve_flat_config(flat)
+    assert cfg["neutralize_proportion"] >= MIN_NEUTRALIZATION_PROPORTION
+
+
+def test_resolve_flat_config_mixed_ensemble_uses_neutralization() -> None:
+    from alphapulse.hpo.search_space import (
+        MIN_NEUTRALIZATION_PROPORTION,
+        resolve_flat_config,
+    )
+
+    flat = {
+        "num_models": 2,
+        "model_1_type": "XGBoost",
+        "model_2_type": "TabPFN",
+        "use_neutralization": True,
+        "neutralization_proportion": 0.2,
+        "scaler_type": "StandardScaler",
+        "use_packboost": False,
+        "ensemble_method": "weighted",
+    }
+    cfg = resolve_flat_config(flat)
     assert cfg["neutralize_proportion"] >= MIN_NEUTRALIZATION_PROPORTION
 
 
 def test_sample_random_config_boosting_enables_neutralization() -> None:
+    foundation_types = {"TabPFN", "TabICL", "TabPFN3", "TabPFN3Reasoning"}
     for seed in range(20):
         config = sample_random_config(seed=seed, fast=True)
         types = [
@@ -137,7 +174,7 @@ def test_sample_random_config_boosting_enables_neutralization() -> None:
             config.get("model_2_type"),
             config.get("model_3_type"),
         ][: config["num_models"]]
-        if "TabPFN" in types or "TabICL" in types:
+        if all(t in foundation_types for t in types):
             assert config["neutralization_proportion"] == 0.0
             assert config["use_neutralization"] is False
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -64,6 +64,24 @@ def test_instantiate_model_matches_model_factory() -> None:
     assert from_builder.n_subs == from_factory.n_subs == 3
 
 
+def test_instantiate_catboost_gpu_strips_colsample_bylevel() -> None:
+    from alphapulse.hpo.builder import instantiate_model
+    from alphapulse.models.catboost_model import CatBoostModel
+    from alphapulse.models.era_ensemble_model import EraEnsembleModel
+
+    model = instantiate_model(
+        "CatBoost",
+        {"params": {"task_type": "GPU", "verbose": 0}},
+        index=0,
+        n_subs=2,
+    )
+    assert isinstance(model, EraEnsembleModel)
+    base = model.base_model_factory()
+    assert isinstance(base, CatBoostModel)
+    assert base.params.get("task_type") == "GPU"
+    assert "colsample_bylevel" not in base.params
+
+
 def test_ensemble_optimizer_fit_predict() -> None:
     rng = np.random.RandomState(0)
     n = 200

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -95,3 +95,28 @@ def test_synthetic_data_augmenter_kde_fit_once() -> None:
     X2, _ = aug.generate()
     assert len(X1) == len(X2) == 10
     assert list(X1.columns) == list("ABC")
+
+
+def test_xgboost_ray_callbacks_return_training_callback_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    import types
+
+    import xgboost as xgb
+
+    from alphapulse.models import xgboost_model
+
+    fake_ray = types.ModuleType("ray")
+    fake_tune = types.ModuleType("ray.tune")
+    fake_session = types.ModuleType("ray.tune.session")
+    fake_session.get_session = lambda: object()  # type: ignore[attr-defined]
+    fake_session.report = lambda metrics: None  # type: ignore[attr-defined]
+    fake_tune.session = fake_session  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setitem(sys.modules, "ray.tune", fake_tune)
+    monkeypatch.setitem(sys.modules, "ray.tune.session", fake_session)
+
+    callbacks = xgboost_model._make_ray_callbacks()
+    assert len(callbacks) == 1
+    assert isinstance(callbacks[0], xgb.callback.TrainingCallback)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -64,6 +64,17 @@ def test_instantiate_model_matches_model_factory() -> None:
     assert from_builder.n_subs == from_factory.n_subs == 3
 
 
+def test_apply_gpu_model_params_lightgbm_sets_device() -> None:
+    from alphapulse.hpo.search_space import apply_gpu_model_params
+
+    params = apply_gpu_model_params("LightGBM", {"params": {"verbosity": -1}})
+    inner = params["params"]
+    assert inner["device"] == "gpu"
+    assert inner["gpu_platform_id"] == 0
+    assert inner["gpu_device_id"] == 0
+    assert "n_jobs" not in inner
+
+
 def test_instantiate_catboost_gpu_strips_colsample_bylevel() -> None:
     from alphapulse.hpo.builder import instantiate_model
     from alphapulse.models.catboost_model import CatBoostModel

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,6 +17,7 @@ from alphapulse.pipeline import Pipeline
 from alphapulse.pipeline.ensemble import EnsembleStrategy
 from alphapulse.pipeline.multi_target import MultiTargetPipeline
 from alphapulse.preprocessors import PCAPreprocessor, StandardScalerPreprocessor
+from alphapulse.preprocessors.feature_selection import VarianceFeatureSelector
 
 
 @pytest.fixture
@@ -245,6 +246,19 @@ class TestInternalValSplit:
         assert len(X_tr) + len(X_va) == len(X)
         assert set(era.loc[X_va.index]).isdisjoint(set(era.loc[X_tr.index]))
 
+    def test_internal_val_split_uses_temporal_last_eras(self) -> None:
+        n_eras, rows_per_era = 10, 4
+        eras = [f"e{i:03d}" for i in range(n_eras)]
+        rng = np.random.RandomState(0)
+        order = rng.permutation(n_eras * rows_per_era)
+        era = pd.Series(np.repeat(eras, rows_per_era)[order])
+        X = pd.DataFrame({"a": np.arange(n_eras * rows_per_era)[order]})
+        y = pd.Series(np.arange(n_eras * rows_per_era)[order] * 0.1)
+        _, _, X_va, _ = internal_val_split(X, y, era_train=era, force_internal=True)
+        assert X_va is not None
+        val_eras = set(era.loc[X_va.index])
+        assert val_eras == {"e009"}
+
     def test_stacking_forces_internal_split(self) -> None:
         X = pd.DataFrame({"a": np.arange(100.0)})
         y = pd.Series(np.arange(100.0))
@@ -296,6 +310,39 @@ def test_all_nan_rows_returns_finite(toy_data: tuple[pd.DataFrame, pd.Series]) -
     preds = pipe.predict(X_bad)
     assert preds.shape == (len(X),)
     assert np.isfinite(preds).all()
+
+
+def test_pipeline_predict_string_index_invalid_row_imputation(
+    toy_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = toy_data
+    X = X.copy()
+    X.index = [f"row_{i}" for i in range(len(X))]
+    y.index = X.index
+    pipe = Pipeline(preprocessors=[StandardScalerPreprocessor()], model=_xgb())
+    pipe.fit(X, y, n_rounds=5)
+    X_mixed = X.copy()
+    X_mixed.iloc[0] = np.nan
+    X_mixed.iloc[3] = np.inf
+    preds = pipe.predict(X_mixed)
+    assert preds.shape == (len(X),)
+    assert np.isfinite(preds).all()
+    assert preds[0] == pytest.approx(np.median(preds[1:]), rel=0.05)
+
+
+def test_variance_selector_in_pipeline_with_era_column(
+    toy_data: tuple[pd.DataFrame, pd.Series],
+) -> None:
+    X, y = toy_data
+    era = pd.Series(np.repeat(["e1", "e2"], len(X) // 2), index=X.index)
+    X = X.assign(era=era)
+    pipe = Pipeline(
+        preprocessors=[VarianceFeatureSelector(keep_fraction=0.5)],
+        model=_xgb(),
+    )
+    pipe.fit(X, y, n_rounds=5)
+    preds = pipe.predict(X)
+    assert preds.shape == (len(X),)
 
 
 def test_numerai_predict_passes_eras_when_neutralization_enabled(

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -1,9 +1,17 @@
+import importlib.util
+
 import numpy as np
 import pandas as pd
 import pytest
 
-from alphapulse.preprocessors.compression import PCAPreprocessor
+from alphapulse.preprocessors.autoencoder import AutoencoderPreprocessor
+from alphapulse.preprocessors.compression import (
+    PCAPreprocessor,
+    TruncatedSVDPreprocessor,
+)
 from alphapulse.preprocessors.noise import GaussianNoiseInjector
+
+HAS_TORCH = importlib.util.find_spec("torch") is not None
 
 
 def test_gaussian_noise_inference_safe_after_fit() -> None:
@@ -60,6 +68,92 @@ def test_pca_with_era_column() -> None:
     out = pca.transform(X)
     assert out.shape == (15, 2)
     assert list(out.columns) == ["pca_0", "pca_1"]
+
+
+def test_pca_deterministic_with_seed() -> None:
+    rng = np.random.RandomState(3)
+    X = pd.DataFrame(rng.randn(30, 6), columns=[f"f{i}" for i in range(6)])
+    out_a = PCAPreprocessor(n_components=3, random_state=0).fit_transform(X)
+    out_b = PCAPreprocessor(n_components=3, random_state=0).fit_transform(X)
+    pd.testing.assert_frame_equal(out_a, out_b)
+
+
+def test_truncated_svd_shape_and_columns() -> None:
+    rng = np.random.RandomState(2)
+    X = pd.DataFrame(rng.randn(20, 8), columns=[f"f{i}" for i in range(8)])
+    svd = TruncatedSVDPreprocessor(n_components=3, random_state=0)
+    out = svd.fit_transform(X)
+    assert out.shape == (20, 3)
+    assert list(out.columns) == ["svd_0", "svd_1", "svd_2"]
+
+
+def test_truncated_svd_deterministic_with_seed() -> None:
+    rng = np.random.RandomState(4)
+    X = pd.DataFrame(rng.randn(25, 5), columns=[f"f{i}" for i in range(5)])
+    out_a = TruncatedSVDPreprocessor(n_components=2, random_state=1).fit_transform(X)
+    out_b = TruncatedSVDPreprocessor(n_components=2, random_state=1).fit_transform(X)
+    pd.testing.assert_frame_equal(out_a, out_b)
+
+
+def test_autoencoder_registered_in_registry() -> None:
+    from alphapulse.hpo.builder import build_preprocessors
+
+    steps = build_preprocessors([{"type": "Autoencoder", "params": {"latent_dim": 2}}])
+    assert isinstance(steps[0], AutoencoderPreprocessor)
+    assert steps[0].latent_dim == 2
+
+
+def test_autoencoder_invalid_latent_dim_raises() -> None:
+    with pytest.raises(ValueError, match="latent_dim"):
+        AutoencoderPreprocessor(latent_dim=0)
+
+
+@pytest.mark.skipif(HAS_TORCH, reason="torch installed — error path unreachable")
+def test_autoencoder_requires_torch() -> None:
+    X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+    with pytest.raises(ImportError, match=r"alphapulse\[deep\]"):
+        AutoencoderPreprocessor(latent_dim=1).fit(X)
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="torch not installed — skip")
+def test_autoencoder_fit_transform_shape() -> None:
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame(rng.randn(40, 8), columns=[f"f{i}" for i in range(8)])
+    ae = AutoencoderPreprocessor(latent_dim=3, epochs=2, batch_size=16, seed=0)
+    out = ae.fit_transform(X)
+    assert out.shape == (40, 3)
+    assert list(out.columns) == ["ae_0", "ae_1", "ae_2"]
+    assert np.isfinite(out.values).all()
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="torch not installed — skip")
+def test_autoencoder_deterministic_with_seed() -> None:
+    rng = np.random.RandomState(1)
+    X = pd.DataFrame(rng.randn(30, 6), columns=[f"f{i}" for i in range(6)])
+    out_a = AutoencoderPreprocessor(latent_dim=2, epochs=2, seed=5).fit_transform(X)
+    out_b = AutoencoderPreprocessor(latent_dim=2, epochs=2, seed=5).fit_transform(X)
+    pd.testing.assert_frame_equal(out_a, out_b)
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="torch not installed — skip")
+def test_autoencoder_nan_safe() -> None:
+    rng = np.random.RandomState(2)
+    X = pd.DataFrame(rng.randn(30, 6), columns=[f"f{i}" for i in range(6)])
+    X.iloc[0, 0] = np.nan
+    X.iloc[5, 3] = np.nan
+    ae = AutoencoderPreprocessor(latent_dim=2, epochs=2, seed=0)
+    out = ae.fit_transform(X)
+    assert np.isfinite(out.values).all()
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="torch not installed — skip")
+def test_autoencoder_ignores_non_numeric_columns() -> None:
+    rng = np.random.RandomState(3)
+    X = pd.DataFrame(rng.randn(20, 5), columns=[f"f{i}" for i in range(5)])
+    X["era"] = ["e1"] * 10 + ["e2"] * 10
+    ae = AutoencoderPreprocessor(latent_dim=2, epochs=2, seed=0)
+    out = ae.fit_transform(X)
+    assert out.shape == (20, 2)
 
 
 def test_era_stable_selector_reduces_features() -> None:

--- a/tests/test_trial_db.py
+++ b/tests/test_trial_db.py
@@ -1,0 +1,84 @@
+"""Tests for HPO trial database persistence and resume behavior."""
+
+from pathlib import Path
+
+from alphapulse.hpo.trial_db import TrialDB
+
+
+def test_insert_trial_replaces_failed_config_on_retry(tmp_path: Path) -> None:
+    db_path = tmp_path / "trials.db"
+    first_config = {"model_1_type": "XGBoost", "xgb_n_rounds": 100}
+    second_config = {"model_1_type": "CatBoost", "catboost_iterations": 200}
+
+    with TrialDB(db_path) as db:
+        db.insert_trial(0, first_config)
+        db.update_trial(0, status="failed", error="boom")
+        db.insert_trial(0, second_config)
+        row = db.load_all_trials()[0]
+
+    assert row["status"] == "running"
+    assert row["flat_config"] == second_config
+    assert row["error"] is None
+
+
+def test_insert_trial_does_not_overwrite_completed(tmp_path: Path) -> None:
+    db_path = tmp_path / "trials.db"
+    completed_config = {"model_1_type": "XGBoost", "xgb_n_rounds": 300}
+    new_config = {"model_1_type": "LightGBM", "lgbm_n_rounds": 400}
+
+    with TrialDB(db_path) as db:
+        db.insert_trial(1, completed_config)
+        db.update_trial(
+            1,
+            status="completed",
+            metrics={"corr_sharpe": 1.5},
+            elapsed_seconds=12.0,
+        )
+        db.insert_trial(1, new_config)
+        row = db.load_all_trials()[0]
+
+    assert row["status"] == "completed"
+    assert row["flat_config"] == completed_config
+
+
+def test_completed_trials_skips_only_successful(tmp_path: Path) -> None:
+    db_path = tmp_path / "trials.db"
+    with TrialDB(db_path) as db:
+        db.insert_trial(0, {"a": 1})
+        db.update_trial(0, status="completed", metrics={"corr_sharpe": 1.0})
+        db.insert_trial(1, {"b": 2})
+        db.update_trial(1, status="failed", error="timeout")
+        assert db.completed_trials() == {0}
+
+
+def test_wandb_group_file_persists_across_resume(tmp_path: Path) -> None:
+    from scripts.hpo_pipeline import _load_or_create_wandb_group
+
+    output_dir = tmp_path / "hpo_run"
+    output_dir.mkdir()
+    first = _load_or_create_wandb_group(output_dir, "alphapulse-hpo")
+    second = _load_or_create_wandb_group(output_dir, "alphapulse-hpo")
+    assert first == second
+    assert (output_dir / "wandb_group.txt").read_text(encoding="utf-8") == first
+
+
+def test_all_results_from_db_includes_all_trials(tmp_path: Path) -> None:
+    from scripts.hpo_pipeline import _all_results_from_db
+
+    db_path = tmp_path / "trials.db"
+    with TrialDB(db_path) as db:
+        db.insert_trial(0, {"model_1_type": "XGBoost"})
+        db.update_trial(
+            0,
+            status="completed",
+            metrics={"corr_sharpe": 1.2},
+            elapsed_seconds=5.0,
+        )
+        db.insert_trial(1, {"model_1_type": "CatBoost"})
+        db.update_trial(1, status="failed", error="timeout", elapsed_seconds=3.0)
+        results = _all_results_from_db(db)
+
+    assert len(results) == 2
+    assert results[0].sharpe == 1.2
+    assert results[1].error == "timeout"
+    assert results[0].params == {"model_1_type": "XGBoost"}


### PR DESCRIPTION
- Add GPU training path for XGBoost, LightGBM, and CatBoost with spawn-based local HPO, fast holdout eval, and foundation model support (TabPFN/TabICL with PCA/SVD/autoencoder compression).
- Default feature neutralization (≥15%) for all non-foundation pipelines; fix synthetic augmentation X/y index alignment bug.
- Integrate per-trial WandB logging with XAI diagnostics (per-era charts, feature exposure, XGBoost SHAP) logged inside subprocess workers under `diagnostics/`.
